### PR TITLE
Complete support for Windows.Foundation.DateTime/TimeSpan/Point/Size/Rect

### DIFF
--- a/Generator/Sources/ProjectionModel/SupportModules.swift
+++ b/Generator/Sources/ProjectionModel/SupportModules.swift
@@ -114,17 +114,17 @@ public enum BuiltInTypeKind {
 extension SupportModules.WinRT {
     private enum BuiltInTypes {
         internal static let windowsFoundation: Dictionary<String, BuiltInTypeKind> = [
-            "DateTime": .definitionOnly,
+            "DateTime": .definitionAndProjection,
             "EventRegistrationToken": .special,
             "HResult": .special,
             "IPropertyValue": .definitionOnly,
             "IReference`1": .definitionAndProjection,
             "IStringable": .definitionAndProjection,
-            "Point": .definitionOnly,
-            "PropertyType": .definitionOnly,
-            "Rect": .definitionOnly,
-            "Size": .definitionOnly,
-            "TimeSpan": .definitionOnly
+            "Point": .definitionAndProjection,
+            "PropertyType": .definitionAndProjection,
+            "Rect": .definitionAndProjection,
+            "Size": .definitionAndProjection,
+            "TimeSpan": .definitionAndProjection
         ]
         internal static let windowsFoundationCollections = [
             "IIterable`1",

--- a/Generator/Sources/SwiftWinRT/Writing/ABIProjectionType.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ABIProjectionType.swift
@@ -13,6 +13,9 @@ internal func writeABIProjectionConformance(_ typeDefinition: TypeDefinition, ge
             let projectionTypeName = try projection.toProjectionTypeName(typeDefinition)
             writer.writeImport(exported: true, kind: .enum, module: SupportModules.WinRT.moduleName, symbolName: projectionTypeName)
         }
+        else {
+            // The struct conforms to ABIProjection itself, and we already imported it.
+        }
         return
     }
 

--- a/Generator/Sources/SwiftWinRT/writeProjectionFiles.swift
+++ b/Generator/Sources/SwiftWinRT/writeProjectionFiles.swift
@@ -29,7 +29,8 @@ internal func writeProjectionFiles(_ projection: SwiftProjection, generateComman
                 try writeTypeDefinitionFile(typeDefinition, module: module, toPath: "\(assemblyNamespaceDirectoryPath)\\\(typeDefinition.nameWithoutGenericSuffix).swift")
             }
 
-            if (typeDefinition as? ClassDefinition)?.isStatic != true {
+            if (typeDefinition as? ClassDefinition)?.isStatic != true,
+                !typeDefinition.isValueType || SupportModules.WinRT.getBuiltInTypeKind(typeDefinition) != .definitionAndProjection {
                 try writeABIProjectionConformanceFile(typeDefinition, module: module,
                     toPath: "\(assemblyNamespaceDirectoryPath)\\Projections\\\(typeDefinition.nameWithoutGenericSuffix)+Projection.swift")
             }

--- a/Support/Sources/WindowsRuntime/IInspectableBoxing.swift
+++ b/Support/Sources/WindowsRuntime/IInspectableBoxing.swift
@@ -14,6 +14,11 @@ public enum IInspectableBoxing {
     public static func box(_ value: Char16) throws -> IInspectable { try PrimitiveProjection.Char16.box(value) }
     public static func box(_ value: String) throws -> IInspectable { try PrimitiveProjection.String.box(value) }
     public static func box(_ value: GUID) throws -> IInspectable { try PrimitiveProjection.Guid.box(value) }
+    public static func box(_ value: WindowsFoundation_DateTime) throws -> IInspectable { try WindowsFoundation_DateTime.box(value) }
+    public static func box(_ value: WindowsFoundation_TimeSpan) throws -> IInspectable { try WindowsFoundation_TimeSpan.box(value) }
+    public static func box(_ value: WindowsFoundation_Point) throws -> IInspectable { try WindowsFoundation_Point.box(value) }
+    public static func box(_ value: WindowsFoundation_Size) throws -> IInspectable { try WindowsFoundation_Size.box(value) }
+    public static func box(_ value: WindowsFoundation_Rect) throws -> IInspectable { try WindowsFoundation_Rect.box(value) }
 
     public static func box<BoxableValue: ValueTypeProjection>(_ value: BoxableValue) throws -> IInspectable {
         try BoxableValue.box(value)

--- a/Support/Sources/WindowsRuntime/PrimitiveProjection.swift
+++ b/Support/Sources/WindowsRuntime/PrimitiveProjection.swift
@@ -5,7 +5,7 @@ public enum PrimitiveProjection {
     public enum Boolean: BoxableProjection, ABIIdentityProjection {
         public static var typeName: Swift.String { "Windows.Foundation.IReference`<Boolean>" }
         public static var ireferenceID: COMInterfaceID { COMInterfaceID(0x3C00FD60, 0x2950, 0x5939, 0xA21A, 0x2D12C5A01B8A) }
-        public static var abiDefaultValue: Swift.Bool { false }
+        public static var abiDefaultValue: CBool { false }
         public static func box(_ value: SwiftValue) throws -> IInspectable {
             try IInspectableProjection.toSwift(PropertyValueStatics.createBoolean(value))
         }
@@ -77,7 +77,7 @@ public enum PrimitiveProjection {
     public enum Single: BoxableProjection, ABIIdentityProjection {
         public static var typeName: Swift.String { "Windows.Foundation.IReference`<Single>" }
         public static var ireferenceID: COMInterfaceID { COMInterfaceID(0x719CC2BA, 0x3E76, 0x5DEF, 0x9F1A, 0x38D85A145EA8) }
-        public static var abiDefaultValue: Swift.Float { 0 }
+        public static var abiDefaultValue: CFloat { 0 }
         public static func box(_ value: SwiftValue) throws -> IInspectable {
             try IInspectableProjection.toSwift(PropertyValueStatics.createSingle(value))
         }
@@ -86,7 +86,7 @@ public enum PrimitiveProjection {
     public enum Double: BoxableProjection, ABIIdentityProjection {
         public static var typeName: Swift.String { "Windows.Foundation.IReference`<Double>" }
         public static var ireferenceID: COMInterfaceID { COMInterfaceID(0x2F2D6C29, 0x5473, 0x5F3E, 0x92E7, 0x96572BB990E2) }
-        public static var abiDefaultValue: Swift.Double { 0 }
+        public static var abiDefaultValue: CDouble { 0 }
         public static func box(_ value: SwiftValue) throws -> IInspectable {
             try IInspectableProjection.toSwift(PropertyValueStatics.createDouble(value))
         }

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/DateTime.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/DateTime.swift
@@ -1,3 +1,7 @@
+// We don't project Windows.Foundation.DataTime to Foundation.Date because
+// the latter can only be constructed from a Foundation.TimeInterval,
+// which is a floating-point number and would lose precision vs DataTime.
+
 /// Represents an instant in time, typically expressed as a date and time of day.
 public struct WindowsFoundation_DateTime: Hashable, Codable, Sendable {
     /// A 64-bit signed integer that represents a point in time as the number of 100-nanosecond intervals prior to or after midnight on January 1, 1601 (according to the Gregorian Calendar).
@@ -26,5 +30,32 @@ extension WindowsFoundation_DateTime {
         set {
             self = Self(foundationDate: newValue)
         }
+    }
+}
+
+import WindowsRuntime_ABI
+
+extension WindowsFoundation_DateTime: WindowsRuntime.StructProjection, COM.ABIInertProjection {
+    public typealias SwiftValue = Self
+    public typealias ABIValue = SWRT_WindowsFoundation_DateTime
+
+    public static let typeName = "Windows.Foundation.DateTime"
+
+    public static var ireferenceID: COM.COMInterfaceID {
+        COMInterfaceID(0x5541D8A7, 0x497C, 0x5AA4, 0x86FC, 0x7713ADBF2A2C)
+    }
+
+    public static var abiDefaultValue: ABIValue { .init() }
+
+    public static func toSwift(_ value: ABIValue) -> SwiftValue {
+        .init(universalTime: value.UniversalTime)
+    }
+
+    public static func toABI(_ value: SwiftValue) -> ABIValue {
+        .init(UniversalTime: value.universalTime)
+    }
+
+    public static func box(_ value: SwiftValue) throws -> IInspectable {
+        try IInspectableProjection.toSwift(PropertyValueStatics.createDateTime(value))
     }
 }

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IPropertyValue.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IPropertyValue.swift
@@ -105,10 +105,14 @@ extension WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue {
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue {
     internal func get_Type() throws -> WindowsFoundation_PropertyType {
+        var abi_value: SWRT_WindowsFoundation_PropertyType = .init()
+        try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.get_Type(this, &abi_value))
         fatalError("Not implemented")
     }
 
     internal func get_IsNumericScalar() throws -> Bool {
-        fatalError("Not implemented")
+        var abi_value: CBool = false
+        try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.get_IsNumericScalar(this, &abi_value))
+        return abi_value
     }
 }

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
@@ -1,5 +1,3 @@
-import WindowsRuntime_ABI
-
 /// Enables arbitrary enumerations, structures, and delegate types to be used as property values.
 public typealias WindowsFoundation_IReference<T> = any WindowsFoundation_IReferenceProtocol<T>
 
@@ -20,6 +18,8 @@ extension WindowsFoundation_IReferenceProtocol {
     /// Gets the type that is represented as an IPropertyValue.
     var value: T { try! _value() }
 }
+
+import WindowsRuntime_ABI
 
 public enum WindowsFoundation_IReferenceProjection<TProjection: BoxableProjection>: InterfaceProjection {
     public typealias SwiftObject = WindowsFoundation_IReference<TProjection.SwiftValue>

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
@@ -1,5 +1,3 @@
-import WindowsRuntime_ABI
-
 /// Provides a way to represent the current object as a string.
 public typealias WindowsFoundation_IStringable = any WindowsFoundation_IStringableProtocol
 
@@ -9,9 +7,11 @@ public protocol WindowsFoundation_IStringableProtocol: IInspectableProtocol {
     func toString() throws -> String
 }
 
+import WindowsRuntime_ABI
+
 public enum WindowsFoundation_IStringableProjection: InterfaceProjection {
     public typealias SwiftObject = WindowsFoundation_IStringable
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_WindowsFoundation_IStringable
+    public typealias COMInterface = SWRT_WindowsFoundation_IStringable
 
     public static var typeName: String { "Windows.Foundation.IStringable" }
     public static var interfaceID: COMInterfaceID { COMInterface.iid }
@@ -31,7 +31,7 @@ public enum WindowsFoundation_IStringableProjection: InterfaceProjection {
         }
     }
 
-    private static var virtualTable: WindowsRuntime_ABI.SWRT_WindowsFoundation_IStringable_VirtualTable = .init(
+    private static var virtualTable: SWRT_WindowsFoundation_IStringable_VirtualTable = .init(
         QueryInterface: { IUnknownVirtualTable.QueryInterface($0, $1, $2) },
         AddRef: { IUnknownVirtualTable.AddRef($0) },
         Release: { IUnknownVirtualTable.Release($0) },
@@ -42,14 +42,14 @@ public enum WindowsFoundation_IStringableProjection: InterfaceProjection {
 }
 
 #if swift(>=5.10)
-extension WindowsRuntime_ABI.SWRT_WindowsFoundation_IStringable: @retroactive COMIUnknownStruct {}
+extension SWRT_WindowsFoundation_IStringable: @retroactive COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_WindowsFoundation_IStringable: /* @retroactive */ COMIInspectableStruct {
+extension SWRT_WindowsFoundation_IStringable: /* @retroactive */ COMIInspectableStruct {
     public static let iid = COMInterfaceID(0x96369F54, 0x8EB6, 0x48F0, 0xABCE, 0xC1B211E627C3);
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_WindowsFoundation_IStringable {
+extension COMInterop where Interface == SWRT_WindowsFoundation_IStringable {
     public func toString() throws -> String {
         var value = PrimitiveProjection.String.abiDefaultValue
         try HResult.throwIfFailed(this.pointee.VirtualTable.pointee.ToString(this, &value))

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/Point.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/Point.swift
@@ -16,3 +16,30 @@ public struct WindowsFoundation_Point: Hashable, Codable, Sendable {
         self.y = y
     }
 }
+
+import WindowsRuntime_ABI
+
+extension WindowsFoundation_Point: WindowsRuntime.StructProjection, COM.ABIInertProjection {
+    public typealias SwiftValue = Self
+    public typealias ABIValue = SWRT_WindowsFoundation_Point
+
+    public static let typeName = "Windows.Foundation.Point"
+
+    public static var ireferenceID: COM.COMInterfaceID {
+        COMInterfaceID(0x84F14C22, 0xA00A, 0x5272, 0x8D3D, 0x82112E66DF00)
+    }
+
+    public static var abiDefaultValue: ABIValue { .init() }
+
+    public static func toSwift(_ value: ABIValue) -> SwiftValue {
+        .init(x: value.X, y: value.Y)
+    }
+
+    public static func toABI(_ value: SwiftValue) -> ABIValue {
+        .init(X: value.x, Y: value.y)
+    }
+
+    public static func box(_ value: SwiftValue) throws -> IInspectable {
+        try IInspectableProjection.toSwift(PropertyValueStatics.createPoint(value))
+    }
+}

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/PropertyType.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/PropertyType.swift
@@ -129,3 +129,11 @@ public struct WindowsFoundation_PropertyType: RawRepresentable, Hashable, Codabl
     /// An array of an unspecified type.
     public static let otherTypeArray = Self(rawValue: 1044)
 }
+
+extension WindowsFoundation_PropertyType: WindowsRuntime.EnumProjection {
+    public static let typeName = "Windows.Foundation.PropertyType"
+
+    public static var ireferenceID: COM.COMInterfaceID {
+        COMInterfaceID(0xECEBDE54, 0xFAC0, 0x5AEB, 0x9BA9, 0x9E1FE17E31D5)
+    }
+}

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/Rect.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/Rect.swift
@@ -26,3 +26,30 @@ public struct WindowsFoundation_Rect: Hashable, Codable, Sendable {
         self.height = height
     }
 }
+
+import WindowsRuntime_ABI
+
+extension WindowsFoundation_Rect: WindowsRuntime.StructProjection, COM.ABIInertProjection {
+    public typealias SwiftValue = Self
+    public typealias ABIValue = SWRT_WindowsFoundation_Rect
+
+    public static let typeName = "Windows.Foundation.Rect"
+
+    public static var ireferenceID: COM.COMInterfaceID {
+        COMInterfaceID(0x80423F11, 0x054F, 0x5EAC, 0xAFD3, 0x63B6CE15E77B)
+    }
+
+    public static var abiDefaultValue: ABIValue { .init() }
+
+    public static func toSwift(_ value: ABIValue) -> SwiftValue {
+        .init(x: value.X, y: value.Y, width: value.Width, height: value.Height)
+    }
+
+    public static func toABI(_ value: SwiftValue) -> ABIValue {
+        .init(X: value.x, Y: value.y, Width: value.width, Height: value.height)
+    }
+
+    public static func box(_ value: SwiftValue) throws -> IInspectable {
+        try IInspectableProjection.toSwift(PropertyValueStatics.createRect(value))
+    }
+}

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/Size.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/Size.swift
@@ -16,3 +16,30 @@ public struct WindowsFoundation_Size: Hashable, Codable, Sendable {
         self.height = height
     }
 }
+
+import WindowsRuntime_ABI
+
+extension WindowsFoundation_Size: WindowsRuntime.StructProjection, COM.ABIInertProjection {
+    public typealias SwiftValue = Self
+    public typealias ABIValue = SWRT_WindowsFoundation_Size
+
+    public static let typeName = "Windows.Foundation.Size"
+
+    public static var ireferenceID: COM.COMInterfaceID {
+        COMInterfaceID(0x61723086, 0x8E53, 0x5276, 0x9F36, 0x2A4BB93E2B75)
+    }
+
+    public static var abiDefaultValue: ABIValue { .init() }
+
+    public static func toSwift(_ value: ABIValue) -> SwiftValue {
+        .init(width: value.Width, height: value.Height)
+    }
+
+    public static func toABI(_ value: SwiftValue) -> SWRT_WindowsFoundation_Size {
+        .init(Width: value.width, Height: value.height)
+    }
+
+    public static func box(_ value: SwiftValue) throws -> IInspectable {
+        try IInspectableProjection.toSwift(PropertyValueStatics.createSize(value))
+    }
+}

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/TimeSpan.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/TimeSpan.swift
@@ -1,5 +1,5 @@
 /// Represents a time interval as a signed 64-bit integer value.
-public struct WindowsFoundation_TimeSpan: Hashable, Codable {
+public struct WindowsFoundation_TimeSpan: Hashable, Codable, Sendable {
     /// A time period expressed in 100-nanosecond units.
     public var duration: Swift.Int64
 
@@ -12,6 +12,25 @@ public struct WindowsFoundation_TimeSpan: Hashable, Codable {
     }
 }
 
+// Conversion to and from Swift.Duration
+extension WindowsFoundation_TimeSpan {
+    private static let secondsPerNanosecond = 1_000_000_000 // 10^−9 seconds
+    private static let nanosecondsPerTick = 100 // 10^−7 seconds
+    private static let ticksPerSecond = secondsPerNanosecond / nanosecondsPerTick
+    private static let attosecondsPerNanosecond = 1_000_000_000
+    private static let attosecondsPerTick = Int64(attosecondsPerNanosecond) * Int64(nanosecondsPerTick)
+
+    public init(duration: Swift.Duration) {
+        self.duration = duration.components.seconds * Int64(Self.ticksPerSecond)
+            + duration.components.attoseconds / Self.attosecondsPerTick
+    }
+
+    public var swiftDuration: Swift.Duration {
+        .nanoseconds(duration * Int64(Self.nanosecondsPerTick))
+    }
+}
+
+// Conversion to and from Foundation.TimeInterval
 import struct Foundation.TimeInterval
 
 extension WindowsFoundation_TimeSpan {
@@ -26,5 +45,33 @@ extension WindowsFoundation_TimeSpan {
         set {
             self = Self(timeInterval: newValue)
         }
+    }
+}
+
+// Projection
+import WindowsRuntime_ABI
+
+/// Projects a Windows.Foundation.TimeSpan into a Swift.Duration value.
+extension WindowsFoundation_TimeSpan: StructProjection, ABIInertProjection {
+    public typealias SwiftValue = WindowsFoundation_TimeSpan
+    public typealias ABIValue = SWRT_WindowsFoundation_TimeSpan
+
+    public static var typeName: String { "Windows.Foundation.TimeSpan" }
+    public static var ireferenceID: COMInterfaceID { 
+        COMInterfaceID(0x604D0C4C, 0x91DE, 0x5C2A, 0x935F, 0x362F13EAF800)
+    }
+
+    public static var abiDefaultValue: ABIValue { .init() }
+
+    public static func toSwift(_ value: ABIValue) -> SwiftValue {
+        .init(duration: value.Duration)
+    }
+
+    public static func toABI(_ value: SwiftValue) -> ABIValue {
+        .init(Duration: value.duration)
+    }
+
+    public static func box(_ value: SwiftValue) throws -> IInspectable {
+        try IInspectableProjection.toSwift(PropertyValueStatics.createTimeSpan(value))
     }
 }

--- a/Support/Sources/WindowsRuntime/PropertyValueStatics.swift
+++ b/Support/Sources/WindowsRuntime/PropertyValueStatics.swift
@@ -109,4 +109,44 @@ internal enum PropertyValueStatics {
         guard let propertyValue else { throw HResult.Error.pointer }
         return COMReference(transferringRef: propertyValue)
     }
+
+    public static func createDateTime(_ value: WindowsFoundation_DateTime) throws -> COMReference<SWRT_IInspectable> {
+        var propertyValue: IInspectablePointer? = nil
+        let value_abi = WindowsFoundation_DateTime.toABI(value)
+        try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.CreateDateTime(this, value_abi, &propertyValue))
+        guard let propertyValue else { throw HResult.Error.pointer }
+        return COMReference(transferringRef: propertyValue)
+    }
+
+    public static func createTimeSpan(_ value: WindowsFoundation_TimeSpan) throws -> COMReference<SWRT_IInspectable> {
+        var propertyValue: IInspectablePointer? = nil
+        let value_abi = WindowsFoundation_TimeSpan.toABI(value)
+        try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.CreateTimeSpan(this, value_abi, &propertyValue))
+        guard let propertyValue else { throw HResult.Error.pointer }
+        return COMReference(transferringRef: propertyValue)
+    }
+
+    public static func createPoint(_ value: WindowsFoundation_Point) throws -> COMReference<SWRT_IInspectable> {
+        var propertyValue: IInspectablePointer? = nil
+        let value_abi = WindowsFoundation_Point.toABI(value)
+        try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.CreatePoint(this, value_abi, &propertyValue))
+        guard let propertyValue else { throw HResult.Error.pointer }
+        return COMReference(transferringRef: propertyValue)
+    }
+
+    public static func createSize(_ value: WindowsFoundation_Size) throws -> COMReference<SWRT_IInspectable> {
+        var propertyValue: IInspectablePointer? = nil
+        let value_abi = WindowsFoundation_Size.toABI(value)
+        try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.CreateSize(this, value_abi, &propertyValue))
+        guard let propertyValue else { throw HResult.Error.pointer }
+        return COMReference(transferringRef: propertyValue)
+    }
+
+    public static func createRect(_ value: WindowsFoundation_Rect) throws -> COMReference<SWRT_IInspectable> {
+        var propertyValue: IInspectablePointer? = nil
+        let value_abi = WindowsFoundation_Rect.toABI(value)
+        try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.CreateRect(this, value_abi, &propertyValue))
+        guard let propertyValue else { throw HResult.Error.pointer }
+        return COMReference(transferringRef: propertyValue)
+    }
 }

--- a/Support/Sources/WindowsRuntime_ABI/include/SWRT/windows.foundation.h
+++ b/Support/Sources/WindowsRuntime_ABI/include/SWRT/windows.foundation.h
@@ -121,11 +121,11 @@ struct SWRT_WindowsFoundation_IPropertyValueStatics_VirtualTable {
     SWRT_HResult (__stdcall *CreateString)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_HString value, SWRT_IInspectable** propertyValue);
     SWRT_HResult (__stdcall *CreateInspectable)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_IInspectable* value, SWRT_IInspectable** propertyValue);
     SWRT_HResult (__stdcall *CreateGuid)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_Guid value, SWRT_IInspectable** propertyValue);
-    void* CreateDateTime; // SWRT_HResult (__stdcall *CreateDateTime)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, Windows.Foundation.DateTime value, SWRT_IInspectable** propertyValue);
-    void* CreateTimeSpan; // SWRT_HResult (__stdcall *CreateTimeSpan)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, Windows.Foundation.TimeSpan value, SWRT_IInspectable** propertyValue);
-    void* CreatePoint; // SWRT_HResult (__stdcall *CreatePoint)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, Windows.Foundation.Point value, SWRT_IInspectable** propertyValue);
-    void* CreateSize; // SWRT_HResult (__stdcall *CreateSize)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, Windows.Foundation.Size value, SWRT_IInspectable** propertyValue);
-    void* CreateRect; // SWRT_HResult (__stdcall *CreateRect)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, Windows.Foundation.Rect value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateDateTime)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_WindowsFoundation_DateTime value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateTimeSpan)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_WindowsFoundation_TimeSpan value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreatePoint)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_WindowsFoundation_Point value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateSize)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_WindowsFoundation_Size value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateRect)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, SWRT_WindowsFoundation_Rect value, SWRT_IInspectable** propertyValue);
     SWRT_HResult (__stdcall *CreateUInt8Array)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, uint8_t* value, SWRT_IInspectable** propertyValue);
     SWRT_HResult (__stdcall *CreateInt16Array)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, int16_t* value, SWRT_IInspectable** propertyValue);
     SWRT_HResult (__stdcall *CreateUInt16Array)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, uint16_t* value, SWRT_IInspectable** propertyValue);
@@ -140,11 +140,11 @@ struct SWRT_WindowsFoundation_IPropertyValueStatics_VirtualTable {
     SWRT_HResult (__stdcall *CreateStringArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_HString* value, SWRT_IInspectable** propertyValue);
     SWRT_HResult (__stdcall *CreateInspectableArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_IInspectable** value, SWRT_IInspectable** propertyValue);
     SWRT_HResult (__stdcall *CreateGuidArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_Guid* value, SWRT_IInspectable** propertyValue);
-    void* CreateDateTimeArray; // SWRT_HResult (__stdcall *CreateDateTimeArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, Windows.Foundation.DateTime* value, SWRT_IInspectable** propertyValue);
-    void* CreateTimeSpanArray; // SWRT_HResult (__stdcall *CreateTimeSpanArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, Windows.Foundation.TimeSpan* value, SWRT_IInspectable** propertyValue);
-    void* CreatePointArray; // SWRT_HResult (__stdcall *CreatePointArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, Windows.Foundation.Point* value, SWRT_IInspectable** propertyValue);
-    void* CreateSizeArray; // SWRT_HResult (__stdcall *CreateSizeArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, Windows.Foundation.Size* value, SWRT_IInspectable** propertyValue);
-    void* CreateRectArray; // SWRT_HResult (__stdcall *CreateRectArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, Windows.Foundation.Rect* value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateDateTimeArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_WindowsFoundation_DateTime* value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateTimeSpanArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_WindowsFoundation_TimeSpan* value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreatePointArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_WindowsFoundation_Point* value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateSizeArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_WindowsFoundation_Size* value, SWRT_IInspectable** propertyValue);
+    SWRT_HResult (__stdcall *CreateRectArray)(SWRT_WindowsFoundation_IPropertyValueStatics* _this, uint32_t __valueSize, SWRT_WindowsFoundation_Rect* value, SWRT_IInspectable** propertyValue);
 };
 
 // // Windows.Foundation.IStringable


### PR DESCRIPTION
Also implements conversion between `TimeSpan` and `Swift.Duration`
Fixes #105