### PR TITLE
Support custom Swift attributes

### DIFF
--- a/Generator/Package.resolved
+++ b/Generator/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/tristanlabelle/swift-dotnetmetadata",
       "state" : {
         "branch" : "main",
-        "revision" : "a0732f6f4ac9e697ad04583c05271d3cdc8a1555"
+        "revision" : "0d40b6e92e18c7fc7eb2900cc1b55d9a140ec31c"
       }
     }
   ],

--- a/Generator/Sources/CodeWriters/Swift/SwiftAttribute.swift
+++ b/Generator/Sources/CodeWriters/Swift/SwiftAttribute.swift
@@ -1,0 +1,4 @@
+public struct SwiftAttribute {
+    public var literal: String
+    public init(_ literal: String) { self.literal = literal }
+}

--- a/Generator/Sources/CodeWriters/Swift/SyntaxWriters/Members.swift
+++ b/Generator/Sources/CodeWriters/Swift/SyntaxWriters/Members.swift
@@ -89,6 +89,7 @@ extension SwiftDeclarationWriter {
 
     public func writeFunc(
         documentation: SwiftDocumentationComment? = nil,
+        attributes: [SwiftAttribute] = [],
         visibility: SwiftVisibility = .implicit,
         static: Bool = false,
         override: Bool = false,
@@ -104,6 +105,7 @@ extension SwiftDeclarationWriter {
         if let documentation { writeDocumentationComment(documentation) }
         output.beginLine(grouping: .never)
         writeFuncHeader(
+            attributes: attributes,
             visibility: visibility,
             static: `static`,
             override: `override`,

--- a/Generator/Sources/CodeWriters/Swift/SyntaxWriters/Protocols.swift
+++ b/Generator/Sources/CodeWriters/Swift/SyntaxWriters/Protocols.swift
@@ -1,6 +1,7 @@
 extension SwiftSourceFileWriter {
     public func writeProtocol(
         documentation: SwiftDocumentationComment? = nil,
+        attributes: [SwiftAttribute] = [],
         visibility: SwiftVisibility = .implicit,
         name: String,
         typeParams: [String] = [],
@@ -9,8 +10,9 @@ extension SwiftSourceFileWriter {
         members: (SwiftProtocolBodyWriter) throws -> Void) rethrows {
 
         var output = output
-        if let documentation = documentation { writeDocumentationComment(documentation) }
         output.beginLine(grouping: .never)
+        if let documentation = documentation { writeDocumentationComment(documentation) }
+        writeAttributes(attributes)
         visibility.write(to: &output, trailingSpace: true)
         output.write("protocol ")
         SwiftIdentifier.write(name, to: &output)
@@ -68,6 +70,7 @@ public struct SwiftProtocolBodyWriter: SwiftSyntaxWriter {
     public func writeFunc(
         documentation: SwiftDocumentationComment? = nil,
         isPropertySetter: Bool = false,
+        attributes: [SwiftAttribute] = [],
         static: Bool = false,
         mutating: Bool = false,
         name: String,
@@ -80,6 +83,7 @@ public struct SwiftProtocolBodyWriter: SwiftSyntaxWriter {
         if let documentation { writeDocumentationComment(documentation) }
         output.beginLine(grouping: .withName(isPropertySetter ? "protocolProperty" : "protocolFunc"))
         writeFuncHeader(
+            attributes: attributes,
             visibility: .implicit,
             static: `static`,
             mutating: `mutating`,

--- a/Generator/Sources/CodeWriters/Swift/SyntaxWriters/SyntaxWriters.swift
+++ b/Generator/Sources/CodeWriters/Swift/SyntaxWriters/SyntaxWriters.swift
@@ -56,7 +56,16 @@ extension SwiftSyntaxWriter {
         output.write(")")
     }
 
+    internal func writeAttributes(_ attributes: [SwiftAttribute]) {
+        for attribute in attributes {
+            output.write("@")
+            output.write(attribute.literal)
+            output.endLine(groupWithNext: true)
+        }
+    }
+
     internal func writeFuncHeader(
+        attributes: [SwiftAttribute] = [],
         visibility: SwiftVisibility = .implicit,
         static: Bool = false,
         override: Bool = false,
@@ -69,6 +78,7 @@ extension SwiftSyntaxWriter {
         returnType: SwiftType? = nil) {
 
         var output = output
+        writeAttributes(attributes)
         visibility.write(to: &output, trailingSpace: true)
         if `static` { output.write("static ") }
         if `override` { output.write("override ") }

--- a/Generator/Sources/CodeWriters/Swift/SyntaxWriters/TypeDeclarations.swift
+++ b/Generator/Sources/CodeWriters/Swift/SyntaxWriters/TypeDeclarations.swift
@@ -12,6 +12,7 @@ extension SwiftDeclarationWriter {
 
     public func writeClass(
         documentation: SwiftDocumentationComment? = nil,
+        attributes: [SwiftAttribute] = [],
         visibility: SwiftVisibility = .implicit,
         final: Bool = false,
         name: String,
@@ -21,8 +22,9 @@ extension SwiftDeclarationWriter {
         definition: (SwiftTypeDefinitionWriter) throws -> Void) rethrows {
 
         var output = output
-        if let documentation { writeDocumentationComment(documentation) }
         output.beginLine(grouping: .never)
+        if let documentation { writeDocumentationComment(documentation) }
+        writeAttributes(attributes)
         visibility.write(to: &output, trailingSpace: true)
         if final { output.write("final ") }
         output.write("class ")
@@ -36,6 +38,7 @@ extension SwiftDeclarationWriter {
 
     public func writeStruct(
         documentation: SwiftDocumentationComment? = nil,
+        attributes: [SwiftAttribute] = [],
         visibility: SwiftVisibility = .implicit,
         name: String,
         typeParams: [String] = [],
@@ -43,8 +46,9 @@ extension SwiftDeclarationWriter {
         definition: (SwiftTypeDefinitionWriter) throws -> Void) rethrows {
 
         var output = output
-        if let documentation { writeDocumentationComment(documentation) }
         output.beginLine(grouping: .never)
+        if let documentation { writeDocumentationComment(documentation) }
+        writeAttributes(attributes)
         visibility.write(to: &output, trailingSpace: true)
         output.write("struct ")
         SwiftIdentifier.write(name, to: &output)
@@ -57,6 +61,7 @@ extension SwiftDeclarationWriter {
 
     public func writeEnum(
         documentation: SwiftDocumentationComment? = nil,
+        attributes: [SwiftAttribute] = [],
         visibility: SwiftVisibility = .implicit,
         name: String,
         typeParams: [String] = [],
@@ -65,8 +70,9 @@ extension SwiftDeclarationWriter {
         definition: (SwiftTypeDefinitionWriter) throws -> Void) rethrows {
 
         var output = output
-        if let documentation { writeDocumentationComment(documentation) }
         output.beginLine(grouping: .never)
+        if let documentation { writeDocumentationComment(documentation) }
+        writeAttributes(attributes)
         visibility.write(to: &output, trailingSpace: true)
         output.write("enum ")
         SwiftIdentifier.write(name, to: &output)

--- a/Generator/Sources/ProjectionModel/SwiftProjection+conversion.swift
+++ b/Generator/Sources/ProjectionModel/SwiftProjection+conversion.swift
@@ -72,6 +72,20 @@ extension SwiftProjection {
         return result
     }
 
+    public static func getSwiftAttributes(_ member: any Attributable) throws -> [SwiftAttribute] {
+        // We recognize any attribute called SwiftAttribute and expect it has a field called Literal,
+        // ideally that would be a positional argument, but IDL doesn't seem to have a syntax for that.
+        try member.attributes
+            .filter { try $0.type.name == "SwiftAttribute" }
+            .compactMap { attribute throws -> SwiftAttribute? in
+                let literalArgument = try attribute.namedArguments[0]
+                guard case .field(let literalField) = literalArgument.target,
+                    literalField.name == "Literal",
+                    case .constant(.string(let literalValue)) = literalArgument.value else { return nil }
+                return Optional(SwiftAttribute(literalValue))
+            }
+    }
+
     public static func toMemberName(_ member: Member) -> String {
         let name = member.name
         

--- a/Generator/Sources/SwiftWinRT/Writing/InterfaceDefinition.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/InterfaceDefinition.swift
@@ -72,6 +72,7 @@ fileprivate func writeProtocol(_ interfaceDefinition: InterfaceDefinition, proje
             guard method.nameKind == .regular else { continue }
             try writer.writeFunc(
                 documentation: projection.getDocumentationComment(method),
+                attributes: SwiftProjection.getSwiftAttributes(method),
                 name: SwiftProjection.toMemberName(method),
                 typeParams: method.genericParams.map { $0.name },
                 params: method.params.map { try projection.toParameter($0) },

--- a/Generator/Sources/SwiftWinRT/Writing/InterfaceImplementation.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/InterfaceImplementation.swift
@@ -141,6 +141,7 @@ fileprivate func writeInterfaceMethodImplementation(
     let (params, returnParam) = try projection.getParamProjections(method: method, genericTypeArgs: typeGenericArgs)
     try writer.writeFunc(
             documentation: documentation ? projection.getDocumentationComment(abiMember: method, classDefinition: classDefinition) : nil,
+            attributes: SwiftProjection.getSwiftAttributes(method),
             visibility: overridable ? .open : .public,
             static: `static`,
             name: SwiftProjection.toMemberName(method),

--- a/Generator/Sources/SwiftWinRT/createProjection.swift
+++ b/Generator/Sources/SwiftWinRT/createProjection.swift
@@ -37,8 +37,7 @@ internal func createProjection(generateCommand: GenerateCommand, projectionConfi
 
         for typeDefinition in assembly.typeDefinitions {
             guard typeDefinition.isPublic else { continue }
-            guard typeDefinition.namespace != "Windows.Foundation.Metadata" else { continue }
-            guard try !typeDefinition.hasAttribute(AttributeUsageAttribute.self) else { continue }
+            guard try !typeDefinition.hasAttribute(WindowsMetadata.AttributeUsageAttribute.self) else { continue }
             guard try !typeDefinition.hasAttribute(ApiContractAttribute.self) else { continue }
             guard typeFilter.matches(typeDefinition.fullName) else { continue }
             try typeDiscoverer.add(typeDefinition)

--- a/InteropTests/WinRTComponent/SwiftAttributes.cpp
+++ b/InteropTests/WinRTComponent/SwiftAttributes.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "SwiftAttributes.h"
+#include "SwiftAttributes.g.cpp"
+
+namespace winrt::WinRTComponent::implementation
+{
+    void SwiftAttributes::MainActor()
+    {
+    }
+    void SwiftAttributes::AvailableFromSwift1()
+    {
+    }
+    int32_t SwiftAttributes::InlinableWithDiscardableResult()
+    {
+        return 42;
+    }
+}

--- a/InteropTests/WinRTComponent/SwiftAttributes.cpp
+++ b/InteropTests/WinRTComponent/SwiftAttributes.cpp
@@ -10,7 +10,7 @@ namespace winrt::WinRTComponent::implementation
     void SwiftAttributes::AvailableFromSwift1()
     {
     }
-    int32_t SwiftAttributes::InlinableWithDiscardableResult()
+    int32_t SwiftAttributes::AvailableFromSwift1WithDiscardableResult()
     {
         return 42;
     }

--- a/InteropTests/WinRTComponent/SwiftAttributes.h
+++ b/InteropTests/WinRTComponent/SwiftAttributes.h
@@ -9,7 +9,7 @@ namespace winrt::WinRTComponent::implementation
 
         static void MainActor();
         static void AvailableFromSwift1();
-        static int32_t InlinableWithDiscardableResult();
+        static int32_t AvailableFromSwift1WithDiscardableResult();
     };
 }
 namespace winrt::WinRTComponent::factory_implementation

--- a/InteropTests/WinRTComponent/SwiftAttributes.h
+++ b/InteropTests/WinRTComponent/SwiftAttributes.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "SwiftAttributes.g.h"
+
+namespace winrt::WinRTComponent::implementation
+{
+    struct SwiftAttributes
+    {
+        SwiftAttributes() = default;
+
+        static void MainActor();
+        static void AvailableFromSwift1();
+        static int32_t InlinableWithDiscardableResult();
+    };
+}
+namespace winrt::WinRTComponent::factory_implementation
+{
+    struct SwiftAttributes : SwiftAttributesT<SwiftAttributes, implementation::SwiftAttributes>
+    {
+    };
+}

--- a/InteropTests/WinRTComponent/SwiftAttributes.idl
+++ b/InteropTests/WinRTComponent/SwiftAttributes.idl
@@ -1,0 +1,22 @@
+namespace WinRTComponent
+{
+    [attributeusage(target_runtimeclass, target_enum, target_struct, target_interface, target_delegate, target_property, target_method)]
+    [allowmultiple]
+    attribute SwiftAttribute
+    {
+        String Literal;
+    }
+
+    static runtimeclass SwiftAttributes
+    {
+        [Swift("MainActor")]
+        static void MainActor();
+
+        [Swift("available(swift 1)")]
+        static void AvailableFromSwift1();
+
+        [Swift("inlinable")]
+        [Swift("discardableResult")]
+        static Int32 InlinableWithDiscardableResult();
+    }
+}

--- a/InteropTests/WinRTComponent/SwiftAttributes.idl
+++ b/InteropTests/WinRTComponent/SwiftAttributes.idl
@@ -15,8 +15,8 @@ namespace WinRTComponent
         [Swift("available(swift 1)")]
         static void AvailableFromSwift1();
 
-        [Swift("inlinable")]
+        [Swift("available(swift 1)")]
         [Swift("discardableResult")]
-        static Int32 InlinableWithDiscardableResult();
+        static Int32 AvailableFromSwift1WithDiscardableResult();
     }
 }

--- a/InteropTests/WinRTComponent/WinRTComponent.vcxproj
+++ b/InteropTests/WinRTComponent/WinRTComponent.vcxproj
@@ -175,6 +175,9 @@
     <ClInclude Include="Structs.h">
       <DependentUpon>Structs.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="SwiftAttributes.h">
+      <DependentUpon>SwiftAttributes.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="WeakReferencer.h">
       <DependentUpon>WeakReferencer.idl</DependentUpon>
     </ClInclude>
@@ -249,6 +252,9 @@
     <ClCompile Include="Structs.cpp">
       <DependentUpon>Structs.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="SwiftAttributes.cpp">
+      <DependentUpon>SwiftAttributes.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="WeakReferencer.cpp">
       <DependentUpon>WeakReferencer.idl</DependentUpon>
     </ClCompile>
@@ -276,6 +282,7 @@
     <Midl Include="ReturnArgument.idl" />
     <Midl Include="Strings.idl" />
     <Midl Include="Structs.idl" />
+    <Midl Include="SwiftAttributes.idl" />
     <Midl Include="WeakReferencer.idl" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Related to #149 for newly authored classes.

```swift
    @MainActor
    public static func mainActor() throws {
        try _iswiftAttributesStatics.mainActor()
    }

    @available(swift 1)
    public static func availableFromSwift1() throws {
        try _iswiftAttributesStatics.availableFromSwift1()
    }

    @discardableResult
    @inlinable
    public static func inlinableWithDiscardableResult() throws -> Swift.Int32 {
        try _iswiftAttributesStatics.inlinableWithDiscardableResult()
    }
```