### PR TITLE
Migrate iid definitions to `uiidof` functions

### DIFF
--- a/Generator/Sources/SwiftWinRT/Writing/ABIProjectionType.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ABIProjectionType.swift
@@ -364,9 +364,9 @@ internal func writeReferenceTypeProjectionConformance(
     // public static var typeName: String { "..." }
     try writeTypeNameProperty(type: apiType, to: writer)
 
-    // public static var interfaceID: COM.COMInterfaceID { COMInterface.iid }
+    // public static var interfaceID: COM.COMInterfaceID { uuidof(COMInterface.self) }
     writer.writeComputedProperty(visibility: .public, static: true, name: "interfaceID", type: SupportModules.COM.comInterfaceID) { writer in
-        writer.writeStatement("COMInterface.iid")
+        writer.writeStatement("uuidof(COMInterface.self)")
     }
 
     if apiType.definition is DelegateDefinition {

--- a/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
@@ -254,9 +254,9 @@ fileprivate func writeClassOverrideSupport(
             params: [ .init(label: "_", name: "id", type: SupportModules.COM.comInterfaceID) ], throws: true,
             returnType: .optional(wrapped: SupportModules.COM.iunknownPointer)) { writer in
         for interface in interfaces {
-            // if id == SWRT_IFoo.iid {
+            // if id == uuidof(SWRT_IFoo.self) {
             let abiSwiftType = try projection.toABIType(interface.asBoundType)
-            try writer.writeBracedBlock("if id == \(abiSwiftType).iid") { writer in
+            try writer.writeBracedBlock("if id == uuidof(\(abiSwiftType).self)") { writer in
                 // if !_ifooOverrides_outer.isInitialized {
                 //     _ifooOverrides_outer = COMEmbedding(
                 //         swiftObject: self, virtualTable: &FooProjection.VirtualTables.ifooOverrides)

--- a/Generator/Sources/SwiftWinRT/Writing/SecondaryInterfaces.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/SecondaryInterfaces.swift
@@ -25,7 +25,7 @@ internal enum SecondaryInterfaces {
             type: SupportModules.COM.comLazyReference(to: abiStructType), initialValue: ".init()")
 
         // private [static] var _istringable: COM.COMInterop<SWRT_WindowsFoundation_IStringable> { get throws {
-        //     try _lazyIStringable.getInterop { try _queryInterface(SWRT_IStringable.iid).cast() }
+        //     try _lazyIStringable.getInterop { try _queryInterface(uuidof(SWRT_IStringable).self).cast() }
         // } }
         let computedPropertyName = getPropertyName(interfaceName: interfaceName)
         let abiInteropType: SwiftType = SupportModules.COM.comInterop(of: abiStructType)
@@ -43,12 +43,12 @@ internal enum SecondaryInterfaces {
                     } else {
                         writer.writeStatement("try \(SupportModules.WinRT.metaclassResolverGlobal).resolve("
                             + "runtimeClass: \"\(activatableId)\", "
-                            + "interfaceID: \(abiStructType).iid)")
+                            + "interfaceID: uuidof(\(abiStructType).self))")
                     }
                 }
                 else {
                     let qiMethodName = composable ? "_queryInnerInterface" : "_queryInterface"
-                    writer.writeStatement("try \(qiMethodName)(\(abiStructType).iid).cast()")
+                    writer.writeStatement("try \(qiMethodName)(uuidof(\(abiStructType).self)).cast()")
                 }
             }
         })

--- a/Support/Sources/COM/COMEmbedding.swift
+++ b/Support/Sources/COM/COMEmbedding.swift
@@ -48,7 +48,7 @@ public struct COMEmbedding /*: ~Copyable */ {
     }
 
     public static func test<Interface>(_ this: UnsafeMutablePointer<Interface>) -> Bool {
-        do { _ = try COMInterop(this).queryInterface(WindowsRuntime_ABI.SWRT_SwiftCOMObject.iid) } catch { return false }
+        do { _ = try COMInterop(this).queryInterface(uuidof(WindowsRuntime_ABI.SWRT_SwiftCOMObject.self)) } catch { return false }
         return true
     }
 
@@ -92,8 +92,8 @@ public struct COMEmbedding /*: ~Copyable */ {
     }
 }
 
-extension WindowsRuntime_ABI.SWRT_SwiftCOMObject {
-    internal static var iid: COMInterfaceID { .init(0x33934271, 0x7009, 0x4EF3, 0x90F1, 0x02090D7EBD64) }
+internal func uuidof(_: WindowsRuntime_ABI.SWRT_SwiftCOMObject.Type) -> COMInterfaceID {
+    .init(0x33934271, 0x7009, 0x4EF3, 0x90F1, 0x02090D7EBD64)
 }
 
 public enum IUnknownVirtualTable {
@@ -130,7 +130,7 @@ public enum IUnknownVirtualTable {
         return HResult.catchValue {
             let id = GUIDProjection.toSwift(iid.pointee)
             let this = IUnknownPointer(OpaquePointer(this))
-            let reference = id == WindowsRuntime_ABI.SWRT_SwiftCOMObject.iid
+            let reference = id == uuidof(WindowsRuntime_ABI.SWRT_SwiftCOMObject.self)
                 ? IUnknownReference(addingRef: this)
                 : try (COMEmbedding.getEmbedderObjectOrCrash(this) as! IUnknown)._queryInterface(id)
             ppvObject.pointee = UnsafeMutableRawPointer(reference.detach())

--- a/Support/Sources/COM/FreeThreadedMarshal.swift
+++ b/Support/Sources/COM/FreeThreadedMarshal.swift
@@ -37,15 +37,15 @@ internal class FreeThreadedMarshal: COMSecondaryExport<FreeThreadedMarshalProjec
     }
 }
 
-extension WindowsRuntime_ABI.SWRT_IMarshal {
-    static var iid: COMInterfaceID { COMInterfaceID(0x00000003, 0x0000, 0x0000, 0xC000, 0x000000000046) }
+internal func uuidof(_: WindowsRuntime_ABI.SWRT_IMarshal.Type) -> COMInterfaceID {
+    .init(0x00000003, 0x0000, 0x0000, 0xC000, 0x000000000046)
 }
 
 internal enum FreeThreadedMarshalProjection: COMTwoWayProjection {
     public typealias SwiftObject = FreeThreadedMarshal
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IMarshal
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {

--- a/Support/Sources/COM/IAgileObject.swift
+++ b/Support/Sources/COM/IAgileObject.swift
@@ -7,7 +7,7 @@ public enum IAgileObjectProjection: COMProjection {
     public typealias SwiftObject = IUnknown // Avoid introducing an interface for IAgileObject since it is a marker interface.
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IAgileObject
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
         IUnknownProjection._wrap(reference.cast())
@@ -18,6 +18,6 @@ public enum IAgileObjectProjection: COMProjection {
     }
 }
 
-extension WindowsRuntime_ABI.SWRT_IAgileObject: /* @retroactive */ COMIUnknownStruct {
-    public static let iid = COMInterfaceID(0x94EA2B94, 0xE9CC, 0x49E0, 0xC0FF, 0xEE64CA8F5B90)
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IAgileObject.Type) -> COMInterfaceID {
+    .init(0x94EA2B94, 0xE9CC, 0x49E0, 0xC0FF, 0xEE64CA8F5B90)
 }

--- a/Support/Sources/COM/IErrorInfo.swift
+++ b/Support/Sources/COM/IErrorInfo.swift
@@ -13,7 +13,7 @@ public enum IErrorInfoProjection: COMTwoWayProjection {
     public typealias SwiftObject = IErrorInfo
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IErrorInfo
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -43,8 +43,8 @@ public enum IErrorInfoProjection: COMTwoWayProjection {
         GetHelpContext: { this, helpContext in _implement(this) { try _set(helpContext, $0.helpContext) } })
 }
 
-extension WindowsRuntime_ABI.SWRT_IErrorInfo: /* @retroactive */ COMIUnknownStruct {
-    public static let iid = COMInterfaceID(0x1CF2B120, 0x547D, 0x101B, 0x8E65, 0x08002B2BD119)
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IErrorInfo.Type) -> COMInterfaceID {
+    .init(0x1CF2B120, 0x547D, 0x101B, 0x8E65, 0x08002B2BD119)
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IErrorInfo {

--- a/Support/Sources/COM/IUnknown.swift
+++ b/Support/Sources/COM/IUnknown.swift
@@ -24,7 +24,7 @@ public enum IUnknownProjection: COMTwoWayProjection {
     public typealias SwiftObject = IUnknown
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IUnknown
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -43,8 +43,11 @@ public enum IUnknownProjection: COMTwoWayProjection {
         Release: { IUnknownVirtualTable.Release($0) })
 }
 
-extension WindowsRuntime_ABI.SWRT_IUnknown: /* @retroactive */ COMIUnknownStruct {
-    public static let iid = COMInterfaceID(0x00000000, 0x0000, 0x0000, 0xC000, 0x000000000046)
+// Originally we extended SWRT_IUnknown to add a static let COMInterfaceID property,
+// however this breaks down when a second Swift module has its own copy of the SWRT_IUnknown
+// and references SWRT_IUnknown.iid. The Swift compiler then doesn't find the extension.
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IUnknown.Type) -> COMInterfaceID {
+    .init(0x00000000, 0x0000, 0x0000, 0xC000, 0x000000000046)
 }
 
 public typealias IUnknownPointer = IUnknownProjection.COMPointer

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IActivationFactory.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IActivationFactory.swift
@@ -11,7 +11,7 @@ public enum IActivationFactoryProjection: InterfaceProjection {
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IActivationFactory
 
     public static var typeName: String { "IActivationFactory" }
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { fatalError("Not implemented: \(#function)") }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -34,8 +34,10 @@ public enum IActivationFactoryProjection: InterfaceProjection {
 extension SWRT_IActivationFactory: @retroactive COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_IActivationFactory: /* @retroactive */ COMIInspectableStruct {
-    public static let iid = COMInterfaceID(0x00000035, 0x0000, 0x0000, 0xC000, 0x000000000046);
+extension WindowsRuntime_ABI.SWRT_IActivationFactory: /* @retroactive */ COMIInspectableStruct {}
+
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IActivationFactory.Type) -> COMInterfaceID {
+    .init(0x00000035, 0x0000, 0x0000, 0xC000, 0x000000000046);
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IActivationFactory {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IBufferByteAccess.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IBufferByteAccess.swift
@@ -11,7 +11,7 @@ public enum IBufferByteAccessProjection: COMTwoWayProjection {
     public typealias SwiftObject = IBufferByteAccess
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IBufferByteAccess
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -39,8 +39,8 @@ extension WindowsRuntime_ABI.SWRT_IBufferByteAccess: @retroactive COMIUnknownStr
 extension WindowsRuntime_ABI.SWRT_IBufferByteAccess: COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_IBufferByteAccess {
-    public static let iid = COMInterfaceID(0x905A0FEF, 0xBC53, 0x11DF, 0x8C49, 0x001E4FC686DA)
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IBufferByteAccess.Type) -> COMInterfaceID {
+    .init(0x905A0FEF, 0xBC53, 0x11DF, 0x8C49, 0x001E4FC686DA)
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IBufferByteAccess {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IInspectable.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IInspectable.swift
@@ -13,7 +13,7 @@ public enum IInspectableProjection: InterfaceProjection {
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IInspectable
 
     public static var typeName: String { "IInspectable" }
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -43,8 +43,10 @@ public protocol COMIInspectableStruct: COMIUnknownStruct {}
 extension WindowsRuntime_ABI.SWRT_IInspectable: @retroactive COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_IInspectable: /* @retroactive */ COMIInspectableStruct {
-    public static let iid = COMInterfaceID(0xAF86E2E0, 0xB12D, 0x4C6A, 0x9C5A, 0xD7AA65101E90)
+extension WindowsRuntime_ABI.SWRT_IInspectable: /* @retroactive */ COMIInspectableStruct {}
+
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IInspectable.Type) -> COMInterfaceID {
+    .init(0xAF86E2E0, 0xB12D, 0x4C6A, 0x9C5A, 0xD7AA65101E90)
 }
 
 public typealias IInspectablePointer = IInspectableProjection.COMPointer

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IMemoryBufferByteAccess.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IMemoryBufferByteAccess.swift
@@ -11,7 +11,7 @@ public enum IMemoryBufferByteAccessProjection: COMTwoWayProjection {
     public typealias SwiftObject = IMemoryBufferByteAccess
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -44,8 +44,8 @@ extension WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess: @retroactive COMIUnkn
 extension WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess: COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess {
-    public static let iid = COMInterfaceID(0x5B0D3235, 0x4DBA, 0x4D44, 0x865E, 0x8F1D0E4FD04D)
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess.Type) -> COMInterfaceID {
+    .init(0x5B0D3235, 0x4DBA, 0x4D44, 0x865E, 0x8F1D0E4FD04D)
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IRestrictedErrorInfo.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IRestrictedErrorInfo.swift
@@ -14,7 +14,7 @@ public enum IRestrictedErrorInfoProjection: COMTwoWayProjection {
     public typealias SwiftObject = IRestrictedErrorInfo
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -66,8 +66,8 @@ extension WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo: @retroactive COMIUnknown
 extension WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo: COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo {
-    public static let iid = COMInterfaceID(0x82BA7092, 0x4C88, 0x427D, 0xA7BC, 0x16DD93FEB67E)
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo.Type) -> COMInterfaceID {
+    .init(0x82BA7092, 0x4C88, 0x427D, 0xA7BC, 0x16DD93FEB67E)
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReference.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReference.swift
@@ -9,7 +9,7 @@ public enum IWeakReferenceProjection: COMTwoWayProjection {
     public typealias SwiftObject = IWeakReference
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IWeakReference
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -46,8 +46,10 @@ public enum IWeakReferenceProjection: COMTwoWayProjection {
 extension WindowsRuntime_ABI.SWRT_IWeakReference: @retroactive COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_IWeakReference: /* @retroactive */ COMIInspectableStruct {
-    public static let iid = COMInterfaceID(0x00000037, 0x0000, 0x0000, 0xC000, 0x000000000046);
+extension WindowsRuntime_ABI.SWRT_IWeakReference: /* @retroactive */ COMIInspectableStruct {}
+
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IWeakReference.Type) -> COMInterfaceID {
+    .init(0x00000037, 0x0000, 0x0000, 0xC000, 0x000000000046);
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IWeakReference {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReferenceSource.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReferenceSource.swift
@@ -9,7 +9,7 @@ public enum IWeakReferenceSourceProjection: COMTwoWayProjection {
     public typealias SwiftObject = IWeakReferenceSource
     public typealias COMInterface = WindowsRuntime_ABI.SWRT_IWeakReferenceSource
 
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -37,8 +37,10 @@ public enum IWeakReferenceSourceProjection: COMTwoWayProjection {
 extension WindowsRuntime_ABI.SWRT_IWeakReferenceSource: @retroactive COMIUnknownStruct {}
 #endif
 
-extension WindowsRuntime_ABI.SWRT_IWeakReferenceSource: /* @retroactive */ COMIInspectableStruct {
-    public static let iid = COMInterfaceID(0x00000038, 0x0000, 0x0000, 0xC000, 0x000000000046);
+extension WindowsRuntime_ABI.SWRT_IWeakReferenceSource: /* @retroactive */ COMIInspectableStruct {}
+
+public func uuidof(_: WindowsRuntime_ABI.SWRT_IWeakReferenceSource.Type) -> COMInterfaceID {
+    .init(0x00000038, 0x0000, 0x0000, 0xC000, 0x000000000046);
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IWeakReferenceSource {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IPropertyValue.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IPropertyValue.swift
@@ -100,8 +100,8 @@ extension WindowsFoundation_IPropertyValueProtocol {
 // extension WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue: WindowsRuntime.COMIInspectableStruct {}
 // #endif
 
-extension WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue {
-    public static let iid = COMInterfaceID(0x4BD682DD, 0x7554, 0x40E9, 0x9A9B, 0x82654EDE7E62)
+public func uuidof(_: WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue.Type) -> COMInterfaceID {
+    .init(0x4BD682DD, 0x7554, 0x40E9, 0x9A9B, 0x82654EDE7E62)
 }
 
 extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
@@ -46,7 +46,7 @@ public enum WindowsFoundation_IReferenceProjection<TProjection: BoxableProjectio
         public var _ipropertyValue: COMInterop<SWRT_WindowsFoundation_IPropertyValue> {
             get throws {
                 try _lazyIPropertyValue.getInterop {
-                    try _queryInterface(SWRT_WindowsFoundation_IPropertyValue.iid)
+                    try _queryInterface(uuidof(SWRT_WindowsFoundation_IPropertyValue.self))
                 }
             }
         }

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
@@ -14,7 +14,7 @@ public enum WindowsFoundation_IStringableProjection: InterfaceProjection {
     public typealias COMInterface = SWRT_WindowsFoundation_IStringable
 
     public static var typeName: String { "Windows.Foundation.IStringable" }
-    public static var interfaceID: COMInterfaceID { COMInterface.iid }
+    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
     public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
@@ -45,8 +45,10 @@ public enum WindowsFoundation_IStringableProjection: InterfaceProjection {
 extension SWRT_WindowsFoundation_IStringable: @retroactive COMIUnknownStruct {}
 #endif
 
-extension SWRT_WindowsFoundation_IStringable: /* @retroactive */ COMIInspectableStruct {
-    public static let iid = COMInterfaceID(0x96369F54, 0x8EB6, 0x48F0, 0xABCE, 0xC1B211E627C3);
+extension SWRT_WindowsFoundation_IStringable: /* @retroactive */ COMIInspectableStruct {}
+
+public func uuidof(_: WindowsRuntime_ABI.SWRT_WindowsFoundation_IStringable.Type) -> COMInterfaceID {
+    .init(0x96369F54, 0x8EB6, 0x48F0, 0xABCE, 0xC1B211E627C3);
 }
 
 extension COMInterop where Interface == SWRT_WindowsFoundation_IStringable {

--- a/Support/Sources/WindowsRuntime/WeakReference.swift
+++ b/Support/Sources/WindowsRuntime/WeakReference.swift
@@ -8,7 +8,7 @@ public final class WeakReference<Projection: ReferenceTypeProjection> {
     public init(_ target: Projection.SwiftObject) throws {
         guard let targetInspectable = target as? IInspectable else { throw HResult.Error.invalidArg }
         let source = try targetInspectable._queryInterface(
-            SWRT_IWeakReferenceSource.iid, type: SWRT_IWeakReferenceSource.self)
+            uuidof(SWRT_IWeakReferenceSource.self), type: SWRT_IWeakReferenceSource.self)
         var weakReference: UnsafeMutablePointer<SWRT_IWeakReference>?
         try WinRTError.throwIfFailed(source.pointer.pointee.VirtualTable.pointee.GetWeakReference(source.pointer, &weakReference))
         guard let weakReference else { throw HResult.Error.fail }


### PR DESCRIPTION
Replaces `SWRT_IFoo.iid` to `uuidof(SWRT_IFoo.self)` as the former caused issues when secondary modules referenced it while referencing a C module defining their own copy of `SWRT_IFoo`.