### PR TITLE
Remove COMIUnknownStruct and rename generic param to ABIStruct

### DIFF
--- a/Generator/Sources/ProjectionModel/SupportModules.swift
+++ b/Generator/Sources/ProjectionModel/SupportModules.swift
@@ -14,7 +14,6 @@ extension SupportModules.COM {
 
     public static var iunknownPointer: SwiftType { .chain(moduleName, "IUnknownPointer") }
     public static var comInterfaceID: SwiftType { .chain(moduleName, "COMInterfaceID") }
-    public static var comIUnknownStruct: SwiftType { .chain(moduleName, "COMIUnknownStruct") }
     public static var nullResult: SwiftType { .chain(moduleName, "NullResult") }
 
     public static var hresult: SwiftType { .chain(moduleName, "HResult") }
@@ -59,7 +58,6 @@ extension SupportModules.WinRT {
 
     public static var char16: SwiftType { .chain(moduleName, "Char16") }
 
-    public static var comIInspectableStruct: SwiftType { .chain(moduleName, "COMIInspectableStruct") }
     public static var eventRegistration: SwiftType { .chain(moduleName, "EventRegistration") }
     public static var eventRegistrationToken: SwiftType { .chain(moduleName, "EventRegistrationToken") }
     public static var iinspectable: SwiftType { .chain(moduleName, "IInspectable") }

--- a/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
@@ -373,12 +373,12 @@ fileprivate func writeSupportComposableInitializers(
         writer.writeStatement("super.init(_transferringRef: .init(OpaquePointer(pointer)))")
     }
 
-    // public init<Interface>(_compose: Bool, _factory: ComposableFactory<Interface>) throws {
+    // public init<ABIStruct>(_compose: Bool, _factory: ComposableFactory<ABIStruct>) throws {
     writer.writeInit(visibility: .public,
             override: true,
-            genericParams: [ "Interface" ],
+            genericParams: [ "ABIStruct" ],
             params: [ SwiftParam(name: "_compose", type: .bool),
-                        SwiftParam(name: "_factory", type: .identifier("ComposableFactory", genericArgs: [ .identifier("Interface") ])) ],
+                        SwiftParam(name: "_factory", type: .identifier("ComposableFactory", genericArgs: [ .identifier("ABIStruct") ])) ],
             throws: true) { writer in
         writer.writeStatement("try super.init(_compose: _compose, _factory: _factory)")
     }

--- a/Support/Sources/COM/COMInterop.swift
+++ b/Support/Sources/COM/COMInterop.swift
@@ -1,28 +1,16 @@
 import WindowsRuntime_ABI
 
-/// Extends COM IUnknown-derived struct definitions with an interface ID.
-/// All conformances will be @retroactive, so this shouldn't be used for dynamic casts.
-public protocol COMIUnknownStruct {
-    // Conceptually, we should have this member:
-    // static var iid: COMInterfaceID { get }
-    //
-    // However this won't work because generic specializations don't belong
-    // to any single module, so we'd run into retroactive conformance issues,
-    // where multiple modules are defining the iid.
-}
-
 /// Wraps a COM interface pointer and exposes projected versions of its methods.
 /// This struct is extended with methods for each COM interface it wraps.
-// Should require COMIUnknownStruct but we run into compiler bugs.
-public struct COMInterop<Interface> /* where Interface: COMIUnknownStruct */ {
-    public let this: UnsafeMutablePointer<Interface>
+public struct COMInterop<ABIStruct> {
+    public let this: UnsafeMutablePointer<ABIStruct>
 
-    public init(_ pointer: UnsafeMutablePointer<Interface>) {
+    public init(_ pointer: UnsafeMutablePointer<ABIStruct>) {
         self.this = pointer
     }
 
     public init<Other>(casting pointer: UnsafeMutablePointer<Other>) {
-        self.init(pointer.withMemoryRebound(to: Interface.self, capacity: 1) { $0 })
+        self.init(pointer.withMemoryRebound(to: ABIStruct.self, capacity: 1) { $0 })
     }
 
     public init<Other>(casting other: COMInterop<Other>) {
@@ -56,7 +44,7 @@ public struct COMInterop<Interface> /* where Interface: COMIUnknownStruct */ {
         return COMReference(transferringRef: pointer)
     }
 
-    public func queryInterface<Other /* COMIUnknownStruct */>(
+    public func queryInterface<Other>(
             _ id: COMInterfaceID, type: Other.Type = Other.self) throws -> COMReference<Other> {
         (try queryInterface(id) as IUnknownReference).cast(to: type)
     }

--- a/Support/Sources/COM/COMLazyReference.swift
+++ b/Support/Sources/COM/COMLazyReference.swift
@@ -1,25 +1,24 @@
 /// Lazily initialized reference to a COM object.
-/// Essentially an Optional<COMReference<Interface>> without language support.
-// Should require COMIUnknownStruct but we run into compiler bugs.
-public struct COMLazyReference<Interface>: ~Copyable /* where Interface: COMIUnknownStruct */ {
-    private var pointer: UnsafeMutablePointer<Interface>?
+/// Essentially an Optional<COMReference<ABIStruct>> without language support.
+public struct COMLazyReference<ABIStruct>: ~Copyable {
+    private var pointer: UnsafeMutablePointer<ABIStruct>?
 
     public init() {
         self.pointer = nil
     }
 
-    public init(_ reference: consuming COMReference<Interface>) {
+    public init(_ reference: consuming COMReference<ABIStruct>) {
         self.pointer = reference.detach()
     }
 
-    public mutating func getPointer(_ factory: () throws -> COMReference<Interface>) rethrows -> UnsafeMutablePointer<Interface> {
+    public mutating func getPointer(_ factory: () throws -> COMReference<ABIStruct>) rethrows -> UnsafeMutablePointer<ABIStruct> {
         if let pointer { return pointer }
         let new = try factory().detach()
         self.pointer = new
         return new
     }
 
-    public mutating func getInterop(_ factory: () throws -> COMReference<Interface>) rethrows -> COMInterop<Interface> {
+    public mutating func getInterop(_ factory: () throws -> COMReference<ABIStruct>) rethrows -> COMInterop<ABIStruct> {
         try COMInterop(getPointer(factory))
     }
 

--- a/Support/Sources/COM/COMProjection.swift
+++ b/Support/Sources/COM/COMProjection.swift
@@ -8,7 +8,7 @@ public protocol COMProjection: ABIProjection where SwiftValue == SwiftObject?, A
     /// The Swift type to which the COM interface is projected.
     associatedtype SwiftObject
     /// The COM interface structure.
-    associatedtype COMInterface /* : COMIUnknownStruct */
+    associatedtype COMInterface
     /// A pointer to the COM interface structure.
     typealias COMPointer = UnsafeMutablePointer<COMInterface>
 

--- a/Support/Sources/COM/COMReference.swift
+++ b/Support/Sources/COM/COMReference.swift
@@ -1,24 +1,23 @@
 import WindowsRuntime_ABI
 
 /// Holds a strong reference to a COM object, like a C++ smart pointer.
-// Should require COMIUnknownStruct but we run into compiler bugs.
-public struct COMReference<Interface>: ~Copyable /* where Interface: COMIUnknownStruct */ {
-    public var pointer: UnsafeMutablePointer<Interface>
+public struct COMReference<ABIStruct>: ~Copyable {
+    public var pointer: UnsafeMutablePointer<ABIStruct>
 
-    public init(transferringRef pointer: UnsafeMutablePointer<Interface>) {
+    public init(transferringRef pointer: UnsafeMutablePointer<ABIStruct>) {
         self.pointer = pointer
     }
 
-    public init(addingRef pointer: UnsafeMutablePointer<Interface>) {
+    public init(addingRef pointer: UnsafeMutablePointer<ABIStruct>) {
         self.init(transferringRef: pointer)
         interop.addRef()
     }
 
-    public var interop: COMInterop<Interface> { .init(pointer) }
+    public var interop: COMInterop<ABIStruct> { .init(pointer) }
 
-    public func clone() -> COMReference<Interface> { .init(addingRef: pointer) }
+    public func clone() -> COMReference<ABIStruct> { .init(addingRef: pointer) }
 
-    public consuming func detach() -> UnsafeMutablePointer<Interface> {
+    public consuming func detach() -> UnsafeMutablePointer<ABIStruct> {
         let pointer = self.pointer
         discard self
         return pointer
@@ -28,12 +27,11 @@ public struct COMReference<Interface>: ~Copyable /* where Interface: COMIUnknown
         try interop.queryInterface(id)
     }
 
-    public func queryInterface<Other>(_ id: COMInterfaceID, type: Other.Type = Other.self) throws -> COMReference<Other> /* where Interface: COMIUnknownStruct */ {
+    public func queryInterface<Other>(_ id: COMInterfaceID, type: Other.Type = Other.self) throws -> COMReference<Other> {
         try interop.queryInterface(id, type: type)
     }
 
-    // Should require COMIUnknownStruct but we run into compiler bugs.
-    public consuming func cast<Other>(to type: Other.Type = Other.self) -> COMReference<Other> /* where Interface: COMIUnknownStruct */ {
+    public consuming func cast<Other>(to type: Other.Type = Other.self) -> COMReference<Other> {
         let pointer = self.pointer
         discard self
         return COMReference<Other>(transferringRef: pointer.withMemoryRebound(to: Other.self, capacity: 1) { $0 })

--- a/Support/Sources/COM/IErrorInfo.swift
+++ b/Support/Sources/COM/IErrorInfo.swift
@@ -47,7 +47,7 @@ public func uuidof(_: WindowsRuntime_ABI.SWRT_IErrorInfo.Type) -> COMInterfaceID
     .init(0x1CF2B120, 0x547D, 0x101B, 0x8E65, 0x08002B2BD119)
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IErrorInfo {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IErrorInfo {
     public func getGuid() throws -> GUID {
         var value = GUIDProjection.abiDefaultValue
         try HResult.throwIfFailed(this.pointee.VirtualTable.pointee.GetGUID(this, &value))

--- a/Support/Sources/COM/IUnknown.swift
+++ b/Support/Sources/COM/IUnknown.swift
@@ -6,8 +6,8 @@ public protocol IUnknownProtocol: AnyObject {
 }
 
 extension IUnknownProtocol {
-    public func _queryInterface<Interface /* COMIUnknownStruct */>(
-            _ id: COMInterfaceID, type: Interface.Type = Interface.self) throws -> COMReference<Interface> {
+    public func _queryInterface<ABIStruct>(
+            _ id: COMInterfaceID, type: ABIStruct.Type = ABIStruct.self) throws -> COMReference<ABIStruct> {
         (try _queryInterface(id) as IUnknownReference).cast(to: type)
     }
 

--- a/Support/Sources/WindowsRuntime/Infra/ComposableClass.swift
+++ b/Support/Sources/WindowsRuntime/Infra/ComposableClass.swift
@@ -24,14 +24,14 @@ open class ComposableClass: IInspectableProtocol {
         outer = .uninitialized
     }
 
-    public typealias ComposableFactory<Interface> = (
+    public typealias ComposableFactory<ABIStruct> = (
         _ outer: IInspectablePointer?,
-        _ inner: inout IInspectablePointer?) throws -> COMReference<Interface>
+        _ inner: inout IInspectablePointer?) throws -> COMReference<ABIStruct>
 
     /// Initializer for instances created in Swift
     /// - Parameter _compose: Whether to create a composed object that supports method overrides in Swift.
     /// - Parameter _factory: A closure calling the WinRT composable activation factory method.
-    public init<Interface>(_compose: Bool, _factory: ComposableFactory<Interface>) throws {
+    public init<ABIStruct>(_compose: Bool, _factory: ComposableFactory<ABIStruct>) throws {
         if _compose {
             // Workaround Swift initialization rules:
             // - Factory needs an initialized outer pointer pointing to self

--- a/Support/Sources/WindowsRuntime/Infra/IInspectableVirtualTable.swift
+++ b/Support/Sources/WindowsRuntime/Infra/IInspectableVirtualTable.swift
@@ -2,8 +2,8 @@ import COM
 import WindowsRuntime_ABI
 
 public enum IInspectableVirtualTable {
-    public static func GetIids<Interface>(
-            _ this: UnsafeMutablePointer<Interface>?,
+    public static func GetIids<ABIStruct>(
+            _ this: UnsafeMutablePointer<ABIStruct>?,
             _ count: UnsafeMutablePointer<UInt32>?,
             _ iids: UnsafeMutablePointer<UnsafeMutablePointer<WindowsRuntime_ABI.SWRT_Guid>?>?) -> WindowsRuntime_ABI.SWRT_HResult {
         guard let this, let count, let iids else { return HResult.invalidArg.value }
@@ -18,8 +18,8 @@ public enum IInspectableVirtualTable {
         }
     }
 
-    public static func GetRuntimeClassName<Interface>(
-            _ this: UnsafeMutablePointer<Interface>?,
+    public static func GetRuntimeClassName<ABIStruct>(
+            _ this: UnsafeMutablePointer<ABIStruct>?,
             _ className: UnsafeMutablePointer<WindowsRuntime_ABI.SWRT_HString?>?) -> WindowsRuntime_ABI.SWRT_HResult {
         guard let this, let className else { return HResult.invalidArg.value }
         className.pointee = nil
@@ -29,8 +29,8 @@ public enum IInspectableVirtualTable {
         }
     }
 
-    public static func GetTrustLevel<Interface>(
-            _ this: UnsafeMutablePointer<Interface>?,
+    public static func GetTrustLevel<ABIStruct>(
+            _ this: UnsafeMutablePointer<ABIStruct>?,
             _ trustLevel: UnsafeMutablePointer<WindowsRuntime_ABI.SWRT_TrustLevel>?) -> WindowsRuntime_ABI.SWRT_HResult {
         guard let this, let trustLevel else { return HResult.invalidArg.value }
         let object = COMEmbedding.getEmbedderObjectOrCrash(this) as! IInspectable

--- a/Support/Sources/WindowsRuntime/Infra/MetaclassResolver.swift
+++ b/Support/Sources/WindowsRuntime/Infra/MetaclassResolver.swift
@@ -12,8 +12,8 @@ public protocol MetaclassResolver {
 }
 
 extension MetaclassResolver {
-    public mutating func resolve<Interface>(runtimeClass: String, interfaceID: COMInterfaceID,
-            type: Interface.Type = Interface.self) throws -> COMReference<Interface> {
+    public mutating func resolve<ABIStruct>(runtimeClass: String, interfaceID: COMInterfaceID,
+            type: ABIStruct.Type = ABIStruct.self) throws -> COMReference<ABIStruct> {
         try resolve(runtimeClass: runtimeClass).queryInterface(interfaceID)
     }
 }
@@ -29,8 +29,8 @@ public struct SystemMetaclassResolver: MetaclassResolver {
         try Self.getActivationFactory(runtimeClass: runtimeClass, interfaceID: IInspectableProjection.interfaceID)
     }
 
-    public static func getActivationFactory<Interface>(runtimeClass: String, interfaceID: COMInterfaceID,
-            type: Interface.Type = Interface.self) throws -> COMReference<Interface> {
+    public static func getActivationFactory<ABIStruct>(runtimeClass: String, interfaceID: COMInterfaceID,
+            type: ABIStruct.Type = ABIStruct.self) throws -> COMReference<ABIStruct> {
         var activatableId = try PrimitiveProjection.String.toABI(runtimeClass)
         defer { PrimitiveProjection.String.release(&activatableId) }
 
@@ -39,7 +39,7 @@ public struct SystemMetaclassResolver: MetaclassResolver {
         try WinRTError.throwIfFailed(WindowsRuntime_ABI.SWRT_RoGetActivationFactory(activatableId, &iid, &rawPointer))
         guard let rawPointer else { throw HResult.Error.noInterface }
 
-        let pointer = rawPointer.bindMemory(to: Interface.self, capacity: 1)
+        let pointer = rawPointer.bindMemory(to: ABIStruct.self, capacity: 1)
         return COM.COMReference(transferringRef: pointer)
     }
 }

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IActivationFactory.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IActivationFactory.swift
@@ -30,17 +30,11 @@ public enum IActivationFactoryProjection: InterfaceProjection {
     }
 }
 
-#if swift(>=6)
-extension SWRT_IActivationFactory: @retroactive COMIUnknownStruct {}
-#endif
-
-extension WindowsRuntime_ABI.SWRT_IActivationFactory: /* @retroactive */ COMIInspectableStruct {}
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_IActivationFactory.Type) -> COMInterfaceID {
     .init(0x00000035, 0x0000, 0x0000, 0xC000, 0x000000000046);
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IActivationFactory {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IActivationFactory {
     // Activation factory methods are special-cased to return the pointer.
     public func activateInstance() throws -> IInspectablePointer? {
         var instance = IInspectableProjection.abiDefaultValue

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IBufferByteAccess.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IBufferByteAccess.swift
@@ -33,17 +33,11 @@ public enum IBufferByteAccessProjection: COMTwoWayProjection {
         Buffer: { this, value in _implement(this) { try _set(value, $0.buffer) } })
 }
 
-#if swift(>=6)
-extension WindowsRuntime_ABI.SWRT_IBufferByteAccess: @retroactive COMIUnknownStruct {}
-#else
-extension WindowsRuntime_ABI.SWRT_IBufferByteAccess: COMIUnknownStruct {}
-#endif
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_IBufferByteAccess.Type) -> COMInterfaceID {
     .init(0x905A0FEF, 0xBC53, 0x11DF, 0x8C49, 0x001E4FC686DA)
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IBufferByteAccess {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IBufferByteAccess {
     public func buffer() throws -> UnsafeMutablePointer<UInt8>? {
         var value: UnsafeMutablePointer<UInt8>? = nil
         try HResult.throwIfFailed(this.pointee.VirtualTable.pointee.Buffer(this, &value))

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IInspectable.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IInspectable.swift
@@ -35,16 +35,6 @@ public enum IInspectableProjection: InterfaceProjection {
         GetTrustLevel: { IInspectableVirtualTable.GetTrustLevel($0, $1) })
 }
 
-/// Identifies COM interface structs as deriving from IInspectable.
-/// Do not use for dynamic casting because conformances will be @retroactive.
-public protocol COMIInspectableStruct: COMIUnknownStruct {}
-
-#if swift(>=6)
-extension WindowsRuntime_ABI.SWRT_IInspectable: @retroactive COMIUnknownStruct {}
-#endif
-
-extension WindowsRuntime_ABI.SWRT_IInspectable: /* @retroactive */ COMIInspectableStruct {}
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_IInspectable.Type) -> COMInterfaceID {
     .init(0xAF86E2E0, 0xB12D, 0x4C6A, 0x9C5A, 0xD7AA65101E90)
 }
@@ -52,8 +42,7 @@ public func uuidof(_: WindowsRuntime_ABI.SWRT_IInspectable.Type) -> COMInterface
 public typealias IInspectablePointer = IInspectableProjection.COMPointer
 public typealias IInspectableReference = COMReference<IInspectableProjection.COMInterface>
 
-// Ideally this would be "where Interface: COMIInspectableStruct", but we run into compiler bugs
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IInspectable {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IInspectable {
     public func getIids() throws -> [COMInterfaceID] {
         var iids: COMArray<WindowsRuntime_ABI.SWRT_Guid> = .null
         try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.GetIids(this, &iids.count, &iids.pointer))

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IMemoryBufferByteAccess.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IMemoryBufferByteAccess.swift
@@ -38,17 +38,11 @@ public enum IMemoryBufferByteAccessProjection: COMTwoWayProjection {
         } })
 }
 
-#if swift(>=6)
-extension WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess: @retroactive COMIUnknownStruct {}
-#else
-extension WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess: COMIUnknownStruct {}
-#endif
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess.Type) -> COMInterfaceID {
     .init(0x5B0D3235, 0x4DBA, 0x4D44, 0x865E, 0x8F1D0E4FD04D)
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess {
     public func getBuffer() throws -> UnsafeMutableBufferPointer<UInt8>? {
         var value: UnsafeMutablePointer<UInt8>? = nil
         var capacity: UInt32 = 0

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IRestrictedErrorInfo.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IRestrictedErrorInfo.swift
@@ -60,17 +60,11 @@ public enum IRestrictedErrorInfoProjection: COMTwoWayProjection {
         GetReference: { this, reference in _implement(this) { try _set(reference, BStrProjection.toABI($0.reference)) } })
 }
 
-#if swift(>=6)
-extension WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo: @retroactive COMIUnknownStruct {}
-#else
-extension WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo: COMIUnknownStruct {}
-#endif
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo.Type) -> COMInterfaceID {
     .init(0x82BA7092, 0x4C88, 0x427D, 0xA7BC, 0x16DD93FEB67E)
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo {
     public func getErrorDetails(
             _ description: inout String?,
             _ error: inout HResult,

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReference.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReference.swift
@@ -42,17 +42,11 @@ public enum IWeakReferenceProjection: COMTwoWayProjection {
         } })
 }
 
-#if swift(>=6)
-extension WindowsRuntime_ABI.SWRT_IWeakReference: @retroactive COMIUnknownStruct {}
-#endif
-
-extension WindowsRuntime_ABI.SWRT_IWeakReference: /* @retroactive */ COMIInspectableStruct {}
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_IWeakReference.Type) -> COMInterfaceID {
     .init(0x00000037, 0x0000, 0x0000, 0xC000, 0x000000000046);
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IWeakReference {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IWeakReference {
     public func resolve(_ iid: COMInterfaceID) throws -> IInspectable? {
         var iid = GUIDProjection.toABI(iid)
         var objectReference = IInspectableProjection.abiDefaultValue

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReferenceSource.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReferenceSource.swift
@@ -33,17 +33,11 @@ public enum IWeakReferenceSourceProjection: COMTwoWayProjection {
         GetWeakReference: { this, weakReference in _implement(this) { try _set(weakReference, IWeakReferenceProjection.toABI($0.getWeakReference())) } })
 }
 
-#if swift(>=6)
-extension WindowsRuntime_ABI.SWRT_IWeakReferenceSource: @retroactive COMIUnknownStruct {}
-#endif
-
-extension WindowsRuntime_ABI.SWRT_IWeakReferenceSource: /* @retroactive */ COMIInspectableStruct {}
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_IWeakReferenceSource.Type) -> COMInterfaceID {
     .init(0x00000038, 0x0000, 0x0000, 0xC000, 0x000000000046);
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_IWeakReferenceSource {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IWeakReferenceSource {
     public func getWeakReference() throws -> IWeakReference? {
         var value = IWeakReferenceProjection.abiDefaultValue
         try HResult.throwIfFailed(this.pointee.VirtualTable.pointee.GetWeakReference(this, &value))

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IPropertyValue.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IPropertyValue.swift
@@ -93,18 +93,11 @@ extension WindowsFoundation_IPropertyValueProtocol {
     public func getRectArray(_ value: inout [WindowsFoundation_Rect]) throws { throw HResult.Error.notImpl }
 }
 
-// Generated projections will declare this conformance
-// #if swift(>=6)
-// extension WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue: @retroactive WindowsRuntime.COMIInspectableStruct {}
-// #else
-// extension WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue: WindowsRuntime.COMIInspectableStruct {}
-// #endif
-
-public func uuidof(_: WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue.Type) -> COMInterfaceID {
+internal func uuidof(_: WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue.Type) -> COMInterfaceID {
     .init(0x4BD682DD, 0x7554, 0x40E9, 0x9A9B, 0x82654EDE7E62)
 }
 
-extension COMInterop where Interface == WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue {
+extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_WindowsFoundation_IPropertyValue {
     internal func get_Type() throws -> WindowsFoundation_PropertyType {
         var abi_value: SWRT_WindowsFoundation_PropertyType = .init()
         try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.get_Type(this, &abi_value))

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
@@ -90,13 +90,7 @@ fileprivate var virtualTable: SWRT_WindowsFoundation_IReference_VirtualTable =  
         return HResult.catch { try reference._getABIValue(value) }.value
     })
 
-#if swift(>=6)
-extension SWRT_WindowsFoundation_IReference: @retroactive WindowsRuntime.COMIInspectableStruct {}
-#else
-extension SWRT_WindowsFoundation_IReference: WindowsRuntime.COMIInspectableStruct {}
-#endif
-
-extension COMInterop where Interface == SWRT_WindowsFoundation_IReference {
+extension COMInterop where ABIStruct == SWRT_WindowsFoundation_IReference {
     public func get_Value(_ value: UnsafeMutableRawPointer) throws {
         try HResult.throwIfFailed(this.pointee.VirtualTable.pointee.get_Value(this, value))
     }

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
@@ -41,17 +41,11 @@ public enum WindowsFoundation_IStringableProjection: InterfaceProjection {
         ToString: { this, value in _implement(this) { try _set(value, PrimitiveProjection.String.toABI($0.toString())) } })
 }
 
-#if swift(>=6)
-extension SWRT_WindowsFoundation_IStringable: @retroactive COMIUnknownStruct {}
-#endif
-
-extension SWRT_WindowsFoundation_IStringable: /* @retroactive */ COMIInspectableStruct {}
-
 public func uuidof(_: WindowsRuntime_ABI.SWRT_WindowsFoundation_IStringable.Type) -> COMInterfaceID {
     .init(0x96369F54, 0x8EB6, 0x48F0, 0xABCE, 0xC1B211E627C3);
 }
 
-extension COMInterop where Interface == SWRT_WindowsFoundation_IStringable {
+extension COMInterop where ABIStruct == SWRT_WindowsFoundation_IStringable {
     public func toString() throws -> String {
         var value = PrimitiveProjection.String.abiDefaultValue
         try HResult.throwIfFailed(this.pointee.VirtualTable.pointee.ToString(this, &value))


### PR DESCRIPTION
Fixes `@retroactive` warnings when building (which were unresolvable)