### PR TITLE
Add COMProjection.ABIReference typealias

### DIFF
--- a/InteropTests/Tests/ActivationFactoryResolutionTests.swift
+++ b/InteropTests/Tests/ActivationFactoryResolutionTests.swift
@@ -8,7 +8,7 @@ class ActivationFactoryResolutionTests: WinRTTestCase {
             private let dllResolver = DllActivationFactoryResolver(name: "WinRTComponent.dll")
             var lastRuntimeClass: String? = nil
 
-            func resolve(runtimeClass: String) throws -> COMReference<IActivationFactoryProjection.COMInterface> {
+            func resolve(runtimeClass: String) throws -> COMReference<IActivationFactoryProjection.ABIStruct> {
                 lastRuntimeClass = runtimeClass
                 return try dllResolver.resolve(runtimeClass: runtimeClass)
             }

--- a/InteropTests/Tests/ClassInheritanceTests.swift
+++ b/InteropTests/Tests/ClassInheritanceTests.swift
@@ -56,7 +56,7 @@ class ClassInheritanceTests : XCTestCase {
     public func testWithUpcasting() throws {
         struct UpcastingSwiftWrapperFactory: SwiftWrapperFactory {
             func create<Projection: COMProjection>(
-                    _ reference: consuming COMReference<Projection.COMInterface>,
+                    _ reference: consuming Projection.ABIReference,
                     projection: Projection.Type) -> Projection.SwiftObject {
                 // Try from the runtime type first, then fall back to the statically known projection
                 if let object: Projection.SwiftObject = fromRuntimeType(

--- a/Support/Sources/COM/COMExportBase.swift
+++ b/Support/Sources/COM/COMExportBase.swift
@@ -11,11 +11,11 @@ open class COMExportBase<Projection: COMTwoWayProjection>: IUnknownProtocol {
         comEmbedding.unknownPointer
     }
 
-    public var comPointer: Projection.COMPointer {
-        Projection.COMPointer(OpaquePointer(comEmbedding.unknownPointer))
+    public var comPointer: Projection.ABIPointer {
+        Projection.ABIPointer(OpaquePointer(comEmbedding.unknownPointer))
     }
 
-    public func toCOM() -> COMReference<Projection.COMInterface> { .init(addingRef: comPointer) }
+    public func toCOM() -> Projection.ABIReference { .init(addingRef: comPointer) }
 
     open func _queryInterface(_ id: COMInterfaceID) throws -> IUnknownReference {
         fatalError("Not implemented. Derived class should have overriden this method.")

--- a/Support/Sources/COM/COMImport.swift
+++ b/Support/Sources/COM/COMImport.swift
@@ -3,16 +3,16 @@ import WindowsRuntime_ABI
 // Base class for COM objects projected into Swift.
 open class COMImport<Projection: COMProjection>: IUnknownProtocol {
     /// A reference to the underlying COM object.
-    public let _reference: COMReference<Projection.COMInterface>
+    public let _reference: Projection.ABIReference
 
     /// A pointer to the underlying COM object.
-    public var _pointer: UnsafeMutablePointer<Projection.COMInterface> { _reference.pointer }
+    public var _pointer: UnsafeMutablePointer<Projection.ABIStruct> { _reference.pointer }
 
     /// The interop wrapper for the underlying COM object.
-    public var _interop: COMInterop<Projection.COMInterface> { _reference.interop }
+    public var _interop: COMInterop<Projection.ABIStruct> { _reference.interop }
 
     /// Initializes a new projection from a COM object reference.
-    public required init(_wrapping reference: consuming COMReference<Projection.COMInterface>) {
+    public required init(_wrapping reference: consuming Projection.ABIReference) {
         self._reference = reference
     }
 
@@ -21,7 +21,7 @@ open class COMImport<Projection: COMProjection>: IUnknownProtocol {
     }
 
     // COMProjection implementation helpers
-    open class func toCOM(_ object: Projection.SwiftObject) throws -> COMReference<Projection.COMInterface> {
+    open class func toCOM(_ object: Projection.SwiftObject) throws -> Projection.ABIReference {
         switch object {
             // If this is already a wrapped COM object, return the wrapped object
             case let comImport as Self: return comImport._reference.clone()

--- a/Support/Sources/COM/COMInterop.swift
+++ b/Support/Sources/COM/COMInterop.swift
@@ -44,8 +44,8 @@ public struct COMInterop<ABIStruct> {
         return COMReference(transferringRef: pointer)
     }
 
-    public func queryInterface<Other>(
-            _ id: COMInterfaceID, type: Other.Type = Other.self) throws -> COMReference<Other> {
+    public func queryInterface<OtherABIStruct>(
+            _ id: COMInterfaceID, type: OtherABIStruct.Type = OtherABIStruct.self) throws -> COMReference<OtherABIStruct> {
         (try queryInterface(id) as IUnknownReference).cast(to: type)
     }
 }

--- a/Support/Sources/COM/COMReference+Optional.swift
+++ b/Support/Sources/COM/COMReference+Optional.swift
@@ -1,6 +1,6 @@
 extension COMReference {
     /// Smart pointer-like reference to a COM object or to nil.
-    /// Essentially an Optional<COMReference<ABIStruct>> without language support.
+    /// Essentially an Optional<ABIReference> without language support.
     public struct Optional: ~Copyable {
         private var pointer: UnsafeMutablePointer<ABIStruct>?
 

--- a/Support/Sources/COM/COMReference.swift
+++ b/Support/Sources/COM/COMReference.swift
@@ -27,14 +27,16 @@ public struct COMReference<ABIStruct>: ~Copyable {
         try interop.queryInterface(id)
     }
 
-    public func queryInterface<Other>(_ id: COMInterfaceID, type: Other.Type = Other.self) throws -> COMReference<Other> {
+    public func queryInterface<OtherABIStruct>(
+            _ id: COMInterfaceID, type: OtherABIStruct.Type = OtherABIStruct.self) throws -> COMReference<OtherABIStruct> {
         try interop.queryInterface(id, type: type)
     }
 
-    public consuming func cast<Other>(to type: Other.Type = Other.self) -> COMReference<Other> {
+    public consuming func cast<OtherABIStruct>(
+            to type: OtherABIStruct.Type = OtherABIStruct.self) -> COMReference<OtherABIStruct> {
         let pointer = self.pointer
         discard self
-        return COMReference<Other>(transferringRef: pointer.withMemoryRebound(to: Other.self, capacity: 1) { $0 })
+        return COMReference<OtherABIStruct>(transferringRef: pointer.withMemoryRebound(to: OtherABIStruct.self, capacity: 1) { $0 })
     }
 
     deinit {

--- a/Support/Sources/COM/COMTwoWayProjection.swift
+++ b/Support/Sources/COM/COMTwoWayProjection.swift
@@ -6,12 +6,12 @@ public protocol COMTwoWayProjection: COMProjection {
 }
 
 extension COMTwoWayProjection {
-    public static func _unwrap(_ pointer: COMPointer) -> SwiftObject? {
+    public static func _unwrap(_ pointer: ABIPointer) -> SwiftObject? {
         COMEmbedding.getImplementation(pointer)
     }
 
     /// Helper for implementing virtual tables
-    public static func _implement(_ this: COMPointer?, _ body: (SwiftObject) throws -> Void) -> WindowsRuntime_ABI.SWRT_HResult {
+    public static func _implement(_ this: ABIPointer?, _ body: (SwiftObject) throws -> Void) -> WindowsRuntime_ABI.SWRT_HResult {
         guard let this else {
             assertionFailure("COM this pointer was null")
             return HResult.pointer.value

--- a/Support/Sources/COM/FreeThreadedMarshal.swift
+++ b/Support/Sources/COM/FreeThreadedMarshal.swift
@@ -43,16 +43,16 @@ internal func uuidof(_: WindowsRuntime_ABI.SWRT_IMarshal.Type) -> COMInterfaceID
 
 internal enum FreeThreadedMarshalProjection: COMTwoWayProjection {
     public typealias SwiftObject = FreeThreadedMarshal
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IMarshal
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IMarshal
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         fatalError("Not implemented")
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         fatalError("Not implemented")
     }
 

--- a/Support/Sources/COM/IAgileObject.swift
+++ b/Support/Sources/COM/IAgileObject.swift
@@ -5,15 +5,15 @@ import WindowsRuntime_ABI
 /// so we don't need to expose a protocol type for it or a two-way projection.
 public enum IAgileObjectProjection: COMProjection {
     public typealias SwiftObject = IUnknown // Avoid introducing an interface for IAgileObject since it is a marker interface.
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IAgileObject
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IAgileObject
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         IUnknownProjection._wrap(reference.cast())
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try object._queryInterface(Self.self)
     }
 }

--- a/Support/Sources/COM/IErrorInfo.swift
+++ b/Support/Sources/COM/IErrorInfo.swift
@@ -11,16 +11,16 @@ public protocol IErrorInfoProtocol: IUnknownProtocol {
 
 public enum IErrorInfoProjection: COMTwoWayProjection {
     public typealias SwiftObject = IErrorInfo
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IErrorInfo
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IErrorInfo
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Sources/COM/IUnknown.swift
+++ b/Support/Sources/COM/IUnknown.swift
@@ -11,7 +11,7 @@ extension IUnknownProtocol {
         (try _queryInterface(id) as IUnknownReference).cast(to: type)
     }
 
-    public func _queryInterface<Projection: COMProjection>(_: Projection.Type) throws -> COMReference<Projection.COMInterface> {
+    public func _queryInterface<Projection: COMProjection>(_: Projection.Type) throws -> Projection.ABIReference {
         try _queryInterface(Projection.interfaceID)
     }
 
@@ -22,16 +22,16 @@ extension IUnknownProtocol {
 
 public enum IUnknownProjection: COMTwoWayProjection {
     public typealias SwiftObject = IUnknown
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IUnknown
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IUnknown
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 
@@ -50,5 +50,5 @@ public func uuidof(_: WindowsRuntime_ABI.SWRT_IUnknown.Type) -> COMInterfaceID {
     .init(0x00000000, 0x0000, 0x0000, 0xC000, 0x000000000046)
 }
 
-public typealias IUnknownPointer = IUnknownProjection.COMPointer
-public typealias IUnknownReference = COMReference<IUnknownProjection.COMInterface>
+public typealias IUnknownPointer = IUnknownProjection.ABIPointer
+public typealias IUnknownReference = IUnknownProjection.ABIReference

--- a/Support/Sources/WindowsRuntime/IReferenceUnboxingProjection.swift
+++ b/Support/Sources/WindowsRuntime/IReferenceUnboxingProjection.swift
@@ -18,13 +18,13 @@ public enum IReferenceUnboxingProjection {
 
     public enum Of<Projection: BoxableProjection>: WinRTProjection, COMProjection {
         public typealias SwiftObject = Projection.SwiftValue
-        public typealias COMInterface = WindowsRuntime_ABI.SWRT_WindowsFoundation_IReference
+        public typealias ABIStruct = WindowsRuntime_ABI.SWRT_WindowsFoundation_IReference
 
         public static var typeName: Swift.String { "Windows.Foundation.IReference`1<\(Projection.typeName)>" }
         public static var interfaceID: COMInterfaceID { Projection.ireferenceID }
 
         // Value types have no identity, so there's no sense unwrapping them.
-        public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+        public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
             var abiValue = Projection.abiDefaultValue
             withUnsafeMutablePointer(to: &abiValue) { abiValuePointer in
                 _ = try! HResult.throwIfFailed(reference.pointer.pointee.VirtualTable.pointee.get_Value(
@@ -33,7 +33,7 @@ public enum IReferenceUnboxingProjection {
             return Projection.toSwift(consuming: &abiValue)
         }
 
-        public static func toCOM(_ value: SwiftObject) throws -> COMReference<COMInterface> {
+        public static func toCOM(_ value: SwiftObject) throws -> ABIReference {
             try Projection.box(value)._queryInterface(interfaceID)
         }
     }

--- a/Support/Sources/WindowsRuntime/Infra/ActivationFactoryResolver.swift
+++ b/Support/Sources/WindowsRuntime/Infra/ActivationFactoryResolver.swift
@@ -6,7 +6,7 @@ import class Foundation.NSLock
 /// aka the COM object that implements the default constructor and
 /// can be QI'd for other factory and static interfaces.
 public protocol ActivationFactoryResolver {
-    mutating func resolve(runtimeClass: String) throws -> COMReference<IActivationFactoryProjection.COMInterface>
+    mutating func resolve(runtimeClass: String) throws -> IActivationFactoryProjection.ABIReference
 }
 
 public var activationFactoryResolver: any ActivationFactoryResolver = SystemActivationFactoryResolver()
@@ -16,7 +16,7 @@ public var activationFactoryResolver: any ActivationFactoryResolver = SystemActi
 public struct SystemActivationFactoryResolver: ActivationFactoryResolver {
     public init() {}
 
-    public func resolve(runtimeClass: String) throws -> COMReference<IActivationFactoryProjection.COMInterface> {
+    public func resolve(runtimeClass: String) throws -> IActivationFactoryProjection.ABIReference {
         try Self.resolve(runtimeClass: runtimeClass, interfaceID: IActivationFactoryProjection.interfaceID)
     }
 
@@ -83,7 +83,7 @@ public final class DllActivationFactoryResolver: ActivationFactoryResolver {
         }
     }
 
-    public func resolve(runtimeClass: String) throws -> COMReference<IActivationFactoryProjection.COMInterface> {
+    public func resolve(runtimeClass: String) throws -> IActivationFactoryProjection.ABIReference {
         var activatableId = try PrimitiveProjection.String.toABI(runtimeClass)
         defer { PrimitiveProjection.String.release(&activatableId) }
 

--- a/Support/Sources/WindowsRuntime/Infra/ProjectionProtocols+extensions.swift
+++ b/Support/Sources/WindowsRuntime/Infra/ProjectionProtocols+extensions.swift
@@ -41,7 +41,7 @@ extension ReferenceTypeProjection {
     }
 
     public static func _getter<Value>(
-            _ this: COMPointer?,
+            _ this: ABIPointer?,
             _ value: UnsafeMutablePointer<Value>?,
             _ code: (SwiftObject) throws -> Value) -> SWRT_HResult {
         _implement(this) {
@@ -65,7 +65,7 @@ extension ComposableClassProjection {
         return swiftWrapperFactory.create(reference, projection: Self.self)
     }
 
-    public static func _unwrap(_ pointer: COMPointer) -> SwiftObject? {
+    public static func _unwrap(_ pointer: ABIPointer) -> SwiftObject? {
         COMEmbedding.getImplementation(pointer, type: SwiftObject.self)
     }
 

--- a/Support/Sources/WindowsRuntime/Infra/SwiftWrapperFactory.swift
+++ b/Support/Sources/WindowsRuntime/Infra/SwiftWrapperFactory.swift
@@ -1,6 +1,6 @@
 public protocol SwiftWrapperFactory {
     func create<Projection: COMProjection>(
-        _ reference: consuming COMReference<Projection.COMInterface>,
+        _ reference: consuming Projection.ABIReference,
         projection: Projection.Type) -> Projection.SwiftObject
 }
 
@@ -8,7 +8,7 @@ public struct DefaultSwiftWrapperFactory: SwiftWrapperFactory {
     public init() {}
 
     public func create<Projection: COMProjection>(
-            _ reference: consuming COMReference<Projection.COMInterface>,
+            _ reference: consuming Projection.ABIReference,
             projection: Projection.Type) -> Projection.SwiftObject {
         Projection._wrap(consume reference)
     }

--- a/Support/Sources/WindowsRuntime/Infra/WinRTExport.swift
+++ b/Support/Sources/WindowsRuntime/Infra/WinRTExport.swift
@@ -7,8 +7,8 @@ open class WinRTPrimaryExport<Projection: InterfaceProjection>: COMPrimaryExport
     open class var implementIStringable: Bool { true }
     open class var implementIWeakReferenceSource: Bool { true }
 
-    public var inspectablePointer: IInspectableProjection.COMPointer {
-        unknownPointer.withMemoryRebound(to: IInspectableProjection.COMInterface.self, capacity: 1) { $0 }
+    public var inspectablePointer: IInspectableProjection.ABIPointer {
+        unknownPointer.withMemoryRebound(to: IInspectableProjection.ABIStruct.self, capacity: 1) { $0 }
     }
 
     open override func _queryInterface(_ id: COMInterfaceID) throws -> IUnknownReference {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IActivationFactory.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IActivationFactory.swift
@@ -8,17 +8,17 @@ public protocol IActivationFactoryProtocol: IInspectableProtocol {
 
 public enum IActivationFactoryProjection: InterfaceProjection {
     public typealias SwiftObject = IActivationFactory
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IActivationFactory
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IActivationFactory
 
     public static var typeName: String { "IActivationFactory" }
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { fatalError("Not implemented: \(#function)") }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 
@@ -43,13 +43,13 @@ extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IActivationFacto
     }
 
     // TODO: Move elsewhere to keep COMInterop only for bridging.
-    public func activateInstance<Projection: WinRTProjection & COMProjection>(projection: Projection.Type) throws -> Projection.COMPointer {
+    public func activateInstance<Projection: WinRTProjection & COMProjection>(projection: Projection.Type) throws -> Projection.ABIPointer {
         var inspectable = IInspectableProjection.abiDefaultValue
         try WinRTError.throwIfFailed(this.pointee.VirtualTable.pointee.ActivateInstance(this, &inspectable))
         defer { IInspectableProjection.release(&inspectable) }
         guard let inspectable else { throw COM.HResult.Error.noInterface }
-        return try COMInterop<IInspectableProjection.COMInterface>(inspectable)
-            .queryInterface(projection.interfaceID, type: Projection.COMInterface.self)
+        return try COMInterop<IInspectableProjection.ABIStruct>(inspectable)
+            .queryInterface(projection.interfaceID, type: Projection.ABIStruct.self)
             .detach()
     }
 }

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IBufferByteAccess.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IBufferByteAccess.swift
@@ -9,16 +9,16 @@ import WindowsRuntime_ABI
 
 public enum IBufferByteAccessProjection: COMTwoWayProjection {
     public typealias SwiftObject = IBufferByteAccess
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IBufferByteAccess
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IBufferByteAccess
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IInspectable.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IInspectable.swift
@@ -10,17 +10,17 @@ public protocol IInspectableProtocol: IUnknownProtocol {
 
 public enum IInspectableProjection: InterfaceProjection {
     public typealias SwiftObject = IInspectable
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IInspectable
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IInspectable
 
     public static var typeName: String { "IInspectable" }
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 
@@ -39,8 +39,8 @@ public func uuidof(_: WindowsRuntime_ABI.SWRT_IInspectable.Type) -> COMInterface
     .init(0xAF86E2E0, 0xB12D, 0x4C6A, 0x9C5A, 0xD7AA65101E90)
 }
 
-public typealias IInspectablePointer = IInspectableProjection.COMPointer
-public typealias IInspectableReference = COMReference<IInspectableProjection.COMInterface>
+public typealias IInspectablePointer = IInspectableProjection.ABIPointer
+public typealias IInspectableReference = IInspectableProjection.ABIReference
 
 extension COMInterop where ABIStruct == WindowsRuntime_ABI.SWRT_IInspectable {
     public func getIids() throws -> [COMInterfaceID] {

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IMemoryBufferByteAccess.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IMemoryBufferByteAccess.swift
@@ -9,16 +9,16 @@ import WindowsRuntime_ABI
 
 public enum IMemoryBufferByteAccessProjection: COMTwoWayProjection {
     public typealias SwiftObject = IMemoryBufferByteAccess
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IMemoryBufferByteAccess
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IRestrictedErrorInfo.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IRestrictedErrorInfo.swift
@@ -12,16 +12,16 @@ public protocol IRestrictedErrorInfoProtocol: IUnknownProtocol {
 
 public enum IRestrictedErrorInfoProjection: COMTwoWayProjection {
     public typealias SwiftObject = IRestrictedErrorInfo
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IRestrictedErrorInfo
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReference.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReference.swift
@@ -7,16 +7,16 @@ public protocol IWeakReferenceProtocol: IUnknownProtocol {
 
 public enum IWeakReferenceProjection: COMTwoWayProjection {
     public typealias SwiftObject = IWeakReference
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IWeakReference
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IWeakReference
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReferenceSource.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/Core/IWeakReferenceSource.swift
@@ -7,16 +7,16 @@ public protocol IWeakReferenceSourceProtocol: IUnknownProtocol {
 
 public enum IWeakReferenceSourceProjection: COMTwoWayProjection {
     public typealias SwiftObject = IWeakReferenceSource
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IWeakReferenceSource
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IWeakReferenceSource
 
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IReference.swift
@@ -23,17 +23,17 @@ import WindowsRuntime_ABI
 
 public enum WindowsFoundation_IReferenceProjection<TProjection: BoxableProjection>: InterfaceProjection {
     public typealias SwiftObject = WindowsFoundation_IReference<TProjection.SwiftValue>
-    public typealias COMInterface = SWRT_WindowsFoundation_IReference
+    public typealias ABIStruct = SWRT_WindowsFoundation_IReference
 
     public static var typeName: String { fatalError("Windows.Foundation.IReference`1<\(TProjection.typeName)>") }
     public static var interfaceID: COMInterfaceID { TProjection.ireferenceID }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: consume reference)
     }
 
-    public static func toCOM(_ value: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ value: SwiftObject) throws -> ABIReference {
         try Import.toCOM(value)
     }
 

--- a/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
+++ b/Support/Sources/WindowsRuntime/ProjectedTypes/WindowsFoundation/IStringable.swift
@@ -11,17 +11,17 @@ import WindowsRuntime_ABI
 
 public enum WindowsFoundation_IStringableProjection: InterfaceProjection {
     public typealias SwiftObject = WindowsFoundation_IStringable
-    public typealias COMInterface = SWRT_WindowsFoundation_IStringable
+    public typealias ABIStruct = SWRT_WindowsFoundation_IStringable
 
     public static var typeName: String { "Windows.Foundation.IStringable" }
-    public static var interfaceID: COMInterfaceID { uuidof(COMInterface.self) }
+    public static var interfaceID: COMInterfaceID { uuidof(ABIStruct.self) }
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Sources/WindowsRuntime/WeakReference.swift
+++ b/Support/Sources/WindowsRuntime/WeakReference.swift
@@ -20,7 +20,7 @@ public final class WeakReference<Projection: ReferenceTypeProjection> {
         var iid = GUIDProjection.toABI(Projection.interfaceID)
         try WinRTError.throwIfFailed(weakReference.pointer.pointee.VirtualTable.pointee.Resolve(
             weakReference.pointer, &iid, &inspectableTarget))
-        var target = Projection.COMPointer(OpaquePointer(inspectableTarget))
+        var target = Projection.ABIPointer(OpaquePointer(inspectableTarget))
         return Projection.toSwift(consuming: &target)
     }
 }

--- a/Support/Tests/IInspectable2.swift
+++ b/Support/Tests/IInspectable2.swift
@@ -6,17 +6,17 @@ internal typealias IInspectable2 = any IInspectable2Protocol
 
 internal enum IInspectable2Projection: InterfaceProjection {
     public typealias SwiftObject = IInspectable2
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IInspectable
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IInspectable
 
     public static var typeName: String { "IInspectable2" }
     public static let interfaceID = COMInterfaceID(0xB6706A54, 0xCC67, 0x4090, 0x822D, 0xE165C8E36C11)
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 

--- a/Support/Tests/IUnknown2.swift
+++ b/Support/Tests/IUnknown2.swift
@@ -6,16 +6,16 @@ internal typealias IUnknown2 = any IUnknown2Protocol
 
 internal enum IUnknown2Projection: COMTwoWayProjection {
     public typealias SwiftObject = IUnknown2
-    public typealias COMInterface = WindowsRuntime_ABI.SWRT_IUnknown
+    public typealias ABIStruct = WindowsRuntime_ABI.SWRT_IUnknown
 
     public static let interfaceID = COMInterfaceID(0x5CF9DEB3, 0xD7C6, 0x42A9, 0x85B3, 0x61D8B68A7B2A)
     public static var virtualTablePointer: UnsafeRawPointer { .init(withUnsafePointer(to: &virtualTable) { $0 }) }
 
-    public static func _wrap(_ reference: consuming COMReference<COMInterface>) -> SwiftObject {
+    public static func _wrap(_ reference: consuming ABIReference) -> SwiftObject {
         Import(_wrapping: reference)
     }
 
-    public static func toCOM(_ object: SwiftObject) throws -> COMReference<COMInterface> {
+    public static func toCOM(_ object: SwiftObject) throws -> ABIReference {
         try Import.toCOM(object)
     }
 


### PR DESCRIPTION
To avoid the longer form `COMReference<FooProjection.COMInterface>`.

Also renames `COMProjection`'s `COMInterface` to `ABIStruct` and `COMPointer` to `ABIPointer`.