### PR TITLE
Use COMReference in ComposableClass.init signature

### DIFF
--- a/Generator/Sources/SwiftWinRT/Writing/ABIProjectionType.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ABIProjectionType.swift
@@ -253,17 +253,12 @@ fileprivate func writeClassProjectionType(
             visibility: SwiftProjection.toVisibility(classDefinition.visibility),
             name: projectionTypeName, protocolConformances: [ projectionProtocol ]) { writer throws in
         let typeName = try projection.toTypeName(classDefinition)
-        let composable = try classDefinition.hasAttribute(ComposableAttribute.self)
 
         try writeReferenceTypeProjectionConformance(
             apiType: classDefinition.bindType(),
             abiType: defaultInterface.asBoundType,
             wrapImpl: { writer, paramName in
-                if composable {
-                    writer.writeStatement("\(typeName)(_transferringRef: \(paramName).detach())")
-                } else {
-                    writer.writeStatement("\(typeName)(_wrapping: consume \(paramName))")
-                }
+                writer.writeStatement("\(typeName)(_wrapping: consume \(paramName))")
             },
             projection: projection,
             to: writer)

--- a/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
@@ -362,14 +362,13 @@ fileprivate func writeActivatableInitializers(
 
 fileprivate func writeSupportComposableInitializers(
         defaultInterface: BoundInterface, projection: SwiftProjection, to writer: SwiftTypeDefinitionWriter) throws {
-    // public init(_transferringRef pointer: UnsafeMutablePointer<CWinRTComponent.SWRT_IFoo>) {
-    //     super.init(_transferringRef: .init(OpaquePointer(pointer))
+    // public init(_wrapping inner: COMReference<CWinRTComponent.SWRT_IFoo>) {
+    //     super.init(_wrapping: inner.cast())
     // }
-    // Should use a COMReference<> but this runs into compiler bugs.
-    let pointerType: SwiftType = .unsafeMutablePointer(to: try projection.toABIType(defaultInterface.asBoundType))
-    let param = SwiftParam(label: "_transferringRef", name: "pointer", type: pointerType)
+    let comReferenceType: SwiftType = SupportModules.COM.comReference(to: try projection.toABIType(defaultInterface.asBoundType))
+    let param = SwiftParam(label: "_wrapping", name: "inner", consuming: true, type: comReferenceType)
     writer.writeInit(visibility: .public, params: [param]) { writer in
-        writer.writeStatement("super.init(_transferringRef: .init(OpaquePointer(pointer)))")
+        writer.writeStatement("super.init(_wrapping: inner.cast()) // Transitively casts down to IInspectable")
     }
 
     // public init<ABIStruct>(_compose: Bool, _factory: ComposableFactory<ABIStruct>) throws {

--- a/Support/Sources/WindowsRuntime/Infra/ComposableClass.swift
+++ b/Support/Sources/WindowsRuntime/Infra/ComposableClass.swift
@@ -16,9 +16,8 @@ open class ComposableClass: IInspectableProtocol {
     private var outer: COMEmbedding
 
     /// Initializer for instances created in WinRT
-    // Should take a COMReference<>, but this runs into cmopiler bugs.
-    public init(_transferringRef pointer: IInspectablePointer) {
-        innerWithRef = pointer
+    public init(_wrapping inner: consuming IInspectableReference) {
+        innerWithRef = inner.detach()
         // The pointer comes from WinRT so we don't have any overrides and there is no outer object.
         // All methods will delegate to the inner object (in this case the full object).
         outer = .uninitialized


### PR DESCRIPTION
Fixes #181 