### PR TITLE
Avoid dots in default names for the modules of assemblies without an explicit mapping

### DIFF
--- a/Generator/Sources/SwiftWinRT/ProjectionConfig.swift
+++ b/Generator/Sources/SwiftWinRT/ProjectionConfig.swift
@@ -32,8 +32,9 @@ struct ProjectionConfig: Codable {
             }
         }
 
+        let moduleName = assemblyName.replacingOccurrences(of: ".", with: "")
         var defaultModule = Module()
         defaultModule.assemblies.append(assemblyName)
-        return (assemblyName, defaultModule)
+        return (moduleName, defaultModule)
     }
 }


### PR DESCRIPTION
Fixes #277