### PR TITLE
Stop generating whole module optimization flag

### DIFF
--- a/Generator/Sources/SwiftWinRT/Writing/SwiftPackageFile.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/SwiftPackageFile.swift
@@ -20,7 +20,6 @@ func writeSwiftPackageFile(_ projection: Projection, spmOptions: SPMOptions, toP
         var projectionModuleTarget: SwiftPackage.Target = .target(name: module.name)
         projectionModuleTarget.path = "\(module.name)/Projection"
         projectionModuleTarget.dependencies.append(.product(name: "WindowsRuntime", package: "Support"))
-        // Cannot add -whole-module-optimization like the CMake code because SPM already adds -enable-batch-mode
 
         for referencedModule in module.references {
             guard !referencedModule.isEmpty else { continue }


### PR DESCRIPTION
It did not clearly make a difference:

```
With wmo
swift-winrt: 306.0073601 seconds
swift-winui-sample: 1299.6790674 seconds

With partial wmo
swift-winrt: 284.5574907 seconds
swift-winui-sample: 1188.8929425 seconds

Without wmo
swift-winrt: 336.6592267 seconds
swift-winui-sample: 1196.5236409 seconds
```