### PR TITLE
Add object lifetime tests to validate that C++ and Swift objects are destroyed

### DIFF
--- a/InteropTests/Tests/LifetimeTests.swift
+++ b/InteropTests/Tests/LifetimeTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import WindowsRuntime
+import WinRTComponent
+
+class LifetimeTests: WinRTTestCase {
+    func testActivatedObjectDestroyedWhenUnreferencedFromSwift() throws {
+        var destroyed: Bool = false
+        withExtendedLifetime(try DestructionCallback { destroyed = true }) {
+            XCTAssertFalse(destroyed)
+        }
+        XCTAssertTrue(destroyed)
+    }
+
+    func testActivatedObjectDestroyedWhenUnreferencedFromWinRT() throws {
+        var destroyed: Bool = false
+        let objectReferencer = try ObjectReferencer(
+            try DestructionCallback { destroyed = true })
+        XCTAssertFalse(destroyed)
+        try objectReferencer.clear()
+        XCTAssertTrue(destroyed)
+    }
+
+    class ComposedDestructionCallback: DestructionCallback, @unchecked Sendable {
+        private let deinitCallback: () -> Void
+
+        public init(winRT: @escaping () -> Void, swift: @escaping () -> Void) throws {
+            self.deinitCallback = swift
+            try super.init(winRT)
+        }
+
+        deinit {
+            deinitCallback()
+        }
+    }
+
+    func testComposedObjectDestroyedWhenUnreferencedFromSwift() throws {
+        var destroyed: Bool = false
+        var deinited: Bool = false
+        withExtendedLifetime(try ComposedDestructionCallback(
+                winRT: { destroyed = true },
+                swift: { deinited = true })) {
+            XCTAssertFalse(destroyed)
+            XCTAssertFalse(deinited)
+        }
+        XCTAssertTrue(destroyed)
+        XCTAssertTrue(deinited)
+    }
+
+    func testComposedObjectDestroyedWhenUnreferencedFromWinRT() throws {
+        var destroyed: Bool = false
+        var deinited: Bool = false
+        let objectReferencer = try ObjectReferencer(
+            try ComposedDestructionCallback(
+                winRT: { destroyed = true },
+                swift: { deinited = true }))
+        XCTAssertFalse(destroyed)
+        XCTAssertFalse(deinited)
+        try objectReferencer.clear()
+        XCTAssertTrue(destroyed)
+        XCTAssertTrue(deinited)
+    }
+}

--- a/InteropTests/WinRTComponent/Dll/DestructionCallback.cpp
+++ b/InteropTests/WinRTComponent/Dll/DestructionCallback.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "MinimalDelegate.g.h"
 #include "DestructionCallback.g.h"
 #include "DestructionCallback.g.cpp"
 

--- a/InteropTests/WinRTComponent/Dll/DestructionCallback.cpp
+++ b/InteropTests/WinRTComponent/Dll/DestructionCallback.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "DestructionCallback.g.h"
-#include "DestructionCallback.g.cpp"
 
 namespace winrt::WinRTComponent::implementation
 {
@@ -18,3 +17,5 @@ namespace winrt::WinRTComponent::factory_implementation
     {
     };
 }
+
+#include "DestructionCallback.g.cpp"

--- a/InteropTests/WinRTComponent/Dll/DestructionCallback.cpp
+++ b/InteropTests/WinRTComponent/Dll/DestructionCallback.cpp
@@ -1,0 +1,21 @@
+#include "pch.h"
+#include "MinimalDelegate.g.h"
+#include "DestructionCallback.g.h"
+#include "DestructionCallback.g.cpp"
+
+namespace winrt::WinRTComponent::implementation
+{
+    struct DestructionCallback : DestructionCallbackT<DestructionCallback>
+    {
+        DestructionCallback(winrt::WinRTComponent::MinimalDelegate const& callback) : m_callback(callback) {}
+        ~DestructionCallback() { m_callback(); }
+
+        winrt::WinRTComponent::MinimalDelegate m_callback;
+    };
+}
+namespace winrt::WinRTComponent::factory_implementation
+{
+    struct DestructionCallback : DestructionCallbackT<DestructionCallback, implementation::DestructionCallback>
+    {
+    };
+}

--- a/InteropTests/WinRTComponent/IDL/DestructionCallback.idl
+++ b/InteropTests/WinRTComponent/IDL/DestructionCallback.idl
@@ -1,0 +1,9 @@
+#include "MinimalTypes.idl"
+
+namespace WinRTComponent
+{
+    unsealed runtimeclass DestructionCallback: [default]IInspectable
+    {
+        DestructionCallback(MinimalDelegate callback);
+    };
+}

--- a/InteropTests/WinRTComponent/IDL/DestructionCallback.idl
+++ b/InteropTests/WinRTComponent/IDL/DestructionCallback.idl
@@ -2,7 +2,8 @@
 
 namespace WinRTComponent
 {
-    unsealed runtimeclass DestructionCallback: [default]IInspectable
+    [default_interface]
+    unsealed runtimeclass DestructionCallback
     {
         DestructionCallback(MinimalDelegate callback);
     };

--- a/InteropTests/WinRTComponent/IDL/WinRTComponent.idl
+++ b/InteropTests/WinRTComponent/IDL/WinRTComponent.idl
@@ -1,10 +1,10 @@
-// Includes all .idl files so we have a single <Midl Include="All.idl"> entry in the vcxproj.
-// This speeds up the build by avoiding multiple midlrt calls followed by an mdmerge step.
+// Includes all .idl files so we can call midlrt only once and avoid slow mdmerge steps.
 #include "Arrays.idl"
 #include "ByteBuffers.idl"
 #include "ClassInheritance.idl"
 #include "Collections.idl"
 #include "DateTimes.idl"
+#include "DestructionCallback.idl"
 #include "DocumentationComments.idl"
 #include "Enums.idl"
 #include "Errors.idl"


### PR DESCRIPTION
Fixes #427