### PR TITLE
Expose ComposableClass.supportsOverrides

### DIFF
--- a/Generator/Sources/CodeWriters/Swift/SyntaxWriters/Members.swift
+++ b/Generator/Sources/CodeWriters/Swift/SyntaxWriters/Members.swift
@@ -44,6 +44,7 @@ extension SwiftDeclarationWriter {
         documentation: SwiftDocumentationComment? = nil,
         visibility: SwiftVisibility = .implicit,
         static: Bool = false,
+        class: Bool = false,
         override: Bool = false,
         name: String,
         type: SwiftType,
@@ -58,6 +59,7 @@ extension SwiftDeclarationWriter {
         output.beginLine(group: .alone)
         visibility.write(to: &output, trailingSpace: true)
         if `static` { output.write("static ") }
+        if `class` { output.write("class ") }
         if `override` { output.write("override ") }
         output.write("var ")
         SwiftIdentifier.write(name, to: &output)

--- a/Generator/Sources/ProjectionModel/SupportModules.swift
+++ b/Generator/Sources/ProjectionModel/SupportModules.swift
@@ -77,6 +77,7 @@ extension SupportModules.WinRT {
     public static var composableClassBinding: SwiftType { .chain(moduleName, "ComposableClassBinding") }
 
     public static var composableClass: SwiftType { .chain(moduleName, "ComposableClass") }
+    public static var composableClass_supportsOverrides: String { "supportsOverrides" }
 
     public static func winRTImport(of type: SwiftType) -> SwiftType {
         .chain([ .init(moduleName), .init("WinRTImport", genericArgs: [type]) ])

--- a/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
@@ -179,7 +179,7 @@ fileprivate func writeInterfaceImplementations(
             thisPointer: thisPointer, projection: projection, to: writer)
     }
 
-    if !classDefinition.isSealed, interfaces.secondary.contains(where: { $0.overidable }) {
+    if !classDefinition.isSealed, interfaces.secondary.contains(where: { $0.overridable }) {
         // open override var supportsOverrides: Bool { Self.self != MyClass.self }
         try writer.writeComputedProperty(
             visibility: .open,

--- a/Support/Sources/WindowsRuntime/ComposableClass.swift
+++ b/Support/Sources/WindowsRuntime/ComposableClass.swift
@@ -10,7 +10,7 @@ import WindowsRuntime_ABI
 /// - Creating a derived Swift class that can override methods
 open class ComposableClass: IInspectableProtocol {
     /// Return true to support overriding WinRT methods in Swift (incurs a size and perf overhead).
-    open class var supportOverrides: Bool { true }
+    open class var supportsOverrides: Bool { true }
 
     /// The inner pointer, which comes from WinRT and implements the base behavior (without overriden methods).
     private var innerWithRef: IInspectablePointer // Strong ref'd (not a COMReference<> because of initialization order issues)
@@ -34,7 +34,7 @@ open class ComposableClass: IInspectableProtocol {
     /// Initializer for instances created in Swift
     /// - Parameter _factory: A closure calling the WinRT composable activation factory method.
     public init<ABIStruct>(_factory: ComposableFactory<ABIStruct>) throws {
-        if Self.supportOverrides {
+        if Self.supportsOverrides {
             // Workaround Swift initialization rules:
             // - Factory needs an initialized outer pointer pointing to self
             // - self.inner needs to be initialized before being able to reference self

--- a/Support/Sources/WindowsRuntime/ComposableClass.swift
+++ b/Support/Sources/WindowsRuntime/ComposableClass.swift
@@ -9,6 +9,9 @@ import WindowsRuntime_ABI
 /// - Creating a new WinRT object, which does not need to support method overrides
 /// - Creating a derived Swift class that can override methods
 open class ComposableClass: IInspectableProtocol {
+    /// Return true to support overriding WinRT methods in Swift (incurs a size and perf overhead).
+    open class var supportOverrides: Bool { true }
+
     /// The inner pointer, which comes from WinRT and implements the base behavior (without overriden methods).
     private var innerWithRef: IInspectablePointer // Strong ref'd (not a COMReference<> because of initialization order issues)
 
@@ -29,10 +32,9 @@ open class ComposableClass: IInspectableProtocol {
         _ inner: inout IInspectablePointer?) throws -> COMReference<ABIStruct>
 
     /// Initializer for instances created in Swift
-    /// - Parameter _compose: Whether to create a composed object that supports method overrides in Swift.
     /// - Parameter _factory: A closure calling the WinRT composable activation factory method.
-    public init<ABIStruct>(_compose: Bool, _factory: ComposableFactory<ABIStruct>) throws {
-        if _compose {
+    public init<ABIStruct>(_factory: ComposableFactory<ABIStruct>) throws {
+        if Self.supportOverrides {
             // Workaround Swift initialization rules:
             // - Factory needs an initialized outer pointer pointing to self
             // - self.inner needs to be initialized before being able to reference self
@@ -65,8 +67,6 @@ open class ComposableClass: IInspectableProtocol {
     open class var queriableInterfaces: [any COMTwoWayBinding.Type] { [] }
 
     public func _queryInnerInterface(_ id: COM.COMInterfaceID) throws -> COM.IUnknownReference {
-        // Workaround for 5.9 compiler bug when using inner.interop directly:
-        // "error: copy of noncopyable typed value. This is a compiler bug"
         try COMInterop(innerWithRef).queryInterface(id)
     }
 
@@ -96,20 +96,14 @@ open class ComposableClass: IInspectableProtocol {
     open func _queryOverridesInterface(_ id: COM.COMInterfaceID) throws -> COM.IUnknownReference.Optional { .none }
 
     open func getIids() throws -> [COM.COMInterfaceID] {
-        // Workaround for 5.9 compiler bug when using inner.interop directly:
-        // "error: copy of noncopyable typed value. This is a compiler bug"
         try COMInterop(innerWithRef).getIids() + Self.queriableInterfaces.map { $0.interfaceID }
     }
 
     open func getRuntimeClassName() throws -> String {
-        // Workaround for 5.9 compiler bug when using inner.interop directly:
-        // "error: copy of noncopyable typed value. This is a compiler bug"
         try COMInterop(innerWithRef).getRuntimeClassName()
     }
 
     open func getTrustLevel() throws -> WindowsRuntime.TrustLevel {
-        // Workaround for 5.9 compiler bug when using inner.interop directly:
-        // "error: copy of noncopyable typed value. This is a compiler bug"
         try COMInterop(innerWithRef).getTrustLevel()
     }
 }


### PR DESCRIPTION
Allows deriving from an unsealed WinRT class without triggering the composable overhead, as needed.