### PR TITLE
Rename COMExport to COMExportBase and COMTearOff to COMTearOffBase

### DIFF
--- a/Docs/How it works.md
+++ b/Docs/How it works.md
@@ -135,7 +135,7 @@ enum IFooBinding: COMBinding { // COMBinding conforms to ABIBinding
 }
 ```
 
-### COMExport Base Class
+### COMExportBase Base Class
 
 What if we want to implement `IFooProtocol` in Swift and pass it to a COM method?
 
@@ -144,11 +144,11 @@ This is a different problem. Now we have a Swift native object that we must turn
 For example:
 
 ```swift
-class MyFoo: COMExport<IFooBinding>, IFooProtocol {
+class MyFoo: COMExportBase<IFooBinding>, IFooProtocol {
     public func getName() throws -> String { "George" }
 }
 
-// COMExport has a field that looks like a COM object:
+// COMExportBase has a field that looks like a COM object:
 // typedef struct SWRT_COMEmbedding {
 //     const void* virtualTable;
 //     void* swiftEmbedder; // Will point back to MyFoo

--- a/Generator/Sources/SwiftWinRT/Extensions/WindowsFoundationCollections_IIterable_swift
+++ b/Generator/Sources/SwiftWinRT/Extensions/WindowsFoundationCollections_IIterable_swift
@@ -9,7 +9,7 @@ extension Sequence {
     }
 }
 
-fileprivate class SequenceIterable<S: Sequence>: WinRTExport<IInspectableBinding>, WindowsFoundationCollections_IIterableProtocol {
+fileprivate class SequenceIterable<S: Sequence>: WinRTExportBase<IInspectableBinding>, WindowsFoundationCollections_IIterableProtocol {
     typealias T = S.Element
 
     private let sequence: S
@@ -23,7 +23,7 @@ fileprivate class SequenceIterable<S: Sequence>: WinRTExport<IInspectableBinding
     }
 }
 
-internal class SequenceIterator<I: IteratorProtocol>: WinRTExport<IInspectableBinding>, WindowsFoundationCollections_IIteratorProtocol {
+internal class SequenceIterator<I: IteratorProtocol>: WinRTExportBase<IInspectableBinding>, WindowsFoundationCollections_IIteratorProtocol {
     typealias T = I.Element
 
     private var iterator: I

--- a/Generator/Sources/SwiftWinRT/Extensions/WindowsFoundationCollections_IVectorView_swift
+++ b/Generator/Sources/SwiftWinRT/Extensions/WindowsFoundationCollections_IVectorView_swift
@@ -12,7 +12,7 @@ extension Collection where Index == Int, Element: Equatable {
     }
 }
 
-fileprivate class CollectionVectorView<C: Collection>: WinRTExport<IInspectableBinding>,
+fileprivate class CollectionVectorView<C: Collection>: WinRTExportBase<IInspectableBinding>,
         WindowsFoundationCollections_IVectorViewProtocol
         where C.Index == Int {
     public typealias T = C.Element

--- a/Generator/Sources/SwiftWinRT/Extensions/WindowsFoundationCollections_IVector_swift
+++ b/Generator/Sources/SwiftWinRT/Extensions/WindowsFoundationCollections_IVector_swift
@@ -13,7 +13,7 @@ extension Array where Element: Equatable {
 }
 
 /// Wraps a Swift array into a type implementing WinRT's Windows.Foundation.Collections.IVector<T>.
-public class ArrayVector<T>: WinRTExport<IInspectableBinding>,
+public class ArrayVector<T>: WinRTExportBase<IInspectableBinding>,
         WindowsFoundationCollections_IVectorProtocol, WindowsFoundationCollections_IVectorViewProtocol {
     public var array: [T]
     public var elementEquals: (T, T) -> Bool

--- a/InteropTests/Tests/EventTests.swift
+++ b/InteropTests/Tests/EventTests.swift
@@ -28,7 +28,7 @@ class EventTests: WinRTTestCase {
         try eventSource.fire()
         XCTAssertEqual(try counter.count, 1)
 
-        class EventSource: WinRTExport<IEventSourceBinding>, IEventSourceProtocol {
+        class EventSource: WinRTExportBase<IEventSourceBinding>, IEventSourceProtocol {
             private var invocationList: EventInvocationList<MinimalDelegate> = .init()
 
             @discardableResult

--- a/InteropTests/Tests/InterfaceImplementationTests.swift
+++ b/InteropTests/Tests/InterfaceImplementationTests.swift
@@ -4,7 +4,7 @@ import WinRTComponent
 
 class InterfaceImplementationTests: WinRTTestCase {
     func testWithSwiftObject() throws {
-        class Exported: WinRTExport<IInspectableBinding>, IMinimalInterfaceProtocol {
+        class Exported: WinRTExportBase<IInspectableBinding>, IMinimalInterfaceProtocol {
             override class var queriableInterfaces: [any COMTwoWayBinding.Type] { [
                 IMinimalInterfaceBinding.self
             ] }

--- a/InteropTests/Tests/ObjectExportingTests.swift
+++ b/InteropTests/Tests/ObjectExportingTests.swift
@@ -3,7 +3,7 @@ import WindowsRuntime
 import WinRTComponent
 
 class ObjectExportingTests: WinRTTestCase {
-    class ExportedClass: WinRTExport<IInspectableBinding> {}
+    class ExportedClass: WinRTExportBase<IInspectableBinding> {}
 
     func testBalancedAddRefRelease() throws {
         let obj: ExportedClass = .init()
@@ -42,7 +42,7 @@ class ObjectExportingTests: WinRTTestCase {
     }
 
     func testWeakReference() throws {
-        class Exported: WinRTExport<IInspectableBinding> {}
+        class Exported: WinRTExportBase<IInspectableBinding> {}
 
         var instance: Exported? = Exported()
         let weakReferencer = try WeakReferencer(XCTUnwrap(instance))

--- a/InteropTests/Tests/ValueOutParamRoundtripTests.swift
+++ b/InteropTests/Tests/ValueOutParamRoundtripTests.swift
@@ -107,7 +107,7 @@ class ValueOutParamRoundtripTests: WinRTTestCase {
         XCTAssertNil(roundtripped)
     }
 
-    class OutputArgumentImplementation: WinRTExport<IOutputArgumentBinding>, IOutputArgumentProtocol {
+    class OutputArgumentImplementation: WinRTExportBase<IOutputArgumentBinding>, IOutputArgumentProtocol {
         func int32(_ value: Int32, _ result: inout Int32) throws { result = value }
         func string(_ value: String, _ result: inout String) throws { result = value }
         func object(_ value: WindowsRuntime.IInspectable?, _ result: inout WindowsRuntime.IInspectable?) throws { result = value }

--- a/InteropTests/Tests/ValueReturnRoundtripTests.swift
+++ b/InteropTests/Tests/ValueReturnRoundtripTests.swift
@@ -86,7 +86,7 @@ class ValueReturnRoundtripTests: WinRTTestCase {
         XCTAssertNil(try twoWay.reference(nil))
     }
 
-    class ReturnArgumentImplementation: WinRTExport<IReturnArgumentBinding>, IReturnArgumentProtocol {
+    class ReturnArgumentImplementation: WinRTExportBase<IReturnArgumentBinding>, IReturnArgumentProtocol {
         func int32(_ value: Int32) throws -> Int32 { value }
         func string(_ value: String) throws -> String { value }
         func object(_ value: WindowsRuntime.IInspectable?) throws -> WindowsRuntime.IInspectable { try NullResult.unwrap(value) }

--- a/Support/Sources/COM/COMDelegatingTearOff.swift
+++ b/Support/Sources/COM/COMDelegatingTearOff.swift
@@ -1,7 +1,7 @@
 import COM_ABI
 
-/// Exposes a secondary COM interface whose implementation is delegated to a primary Swift exported object.
-public final class COMDelegatingExport: COMEmbedderEx {
+/// A COM tear-off object providing a COM virtual table for an interface implemented by the Swift owner object.
+public final class COMDelegatingTearOff: COMEmbedderEx {
     private var comEmbedding: COMEmbedding
 
     public init(virtualTable: UnsafeRawPointer, implementer: IUnknown) {

--- a/Support/Sources/COM/COMError+SwiftErrorInfo.swift
+++ b/Support/Sources/COM/COMError+SwiftErrorInfo.swift
@@ -1,6 +1,6 @@
 extension COMError {
     /// Wraps a Swift Error object into an `IErrorInfo` to preserve it across COM boundaries.
-    internal final class SwiftErrorInfo: COMExport<IErrorInfoBinding>, IErrorInfoProtocol {
+    internal final class SwiftErrorInfo: COMExportBase<IErrorInfoBinding>, IErrorInfoProtocol {
         public let error: Error
 
         public init(error: Error) {

--- a/Support/Sources/COM/COMExportBase.swift
+++ b/Support/Sources/COM/COMExportBase.swift
@@ -1,7 +1,7 @@
 /// Base for Swift classes that implement one or more COM interfaces and owns the COM object identity,
 /// meaning that they own the object returned when using QueryInterface for IUnknown.
 /// The generic Binding parameter determines the virtual table of the identity object.
-open class COMExport<PrimaryInterfaceBinding: COMTwoWayBinding>: IUnknownProtocol {
+open class COMExportBase<PrimaryInterfaceBinding: COMTwoWayBinding>: IUnknownProtocol {
     /// Gets the interfaces that can be queried for using queryInterface.
     open class var queriableInterfaces: [any COMTwoWayBinding.Type] { [] }
     open class var implementIAgileObject: Bool { true }
@@ -26,7 +26,7 @@ open class COMExport<PrimaryInterfaceBinding: COMTwoWayBinding>: IUnknownProtoco
                 return try FreeThreadedMarshal(self).toCOM().cast()
             default:
                 if let interfaceBinding = Self.queriableInterfaces.first(where: { $0.interfaceID == id }) {
-                    return COMDelegatingExport(virtualTable: interfaceBinding.virtualTablePointer, implementer: self).toCOM()
+                    return COMDelegatingTearOff(virtualTable: interfaceBinding.virtualTablePointer, implementer: self).toCOM()
                 }
                 throw COMError.noInterface
         }

--- a/Support/Sources/COM/COMTearOffBase.swift
+++ b/Support/Sources/COM/COMTearOffBase.swift
@@ -1,5 +1,5 @@
 /// A COM-exported object providing a secondary interface to a primary exported object.
-open class COMTearOff<InterfaceBinding: COMTwoWayBinding>: IUnknownProtocol {
+open class COMTearOffBase<InterfaceBinding: COMTwoWayBinding>: IUnknownProtocol {
     private var implements: COMImplements<InterfaceBinding> = .init()
     public let owner: IUnknown
 

--- a/Support/Sources/COM/FreeThreadedMarshal.swift
+++ b/Support/Sources/COM/FreeThreadedMarshal.swift
@@ -1,7 +1,7 @@
 import COM_ABI
 
 /// Provides an implementation of IMarshal based on the COM free-threaded marshaler.
-public final class FreeThreadedMarshal: COMTearOff<FreeThreadedMarshalBinding> {
+public final class FreeThreadedMarshal: COMTearOffBase<FreeThreadedMarshalBinding> {
     private let marshaler: COMReference<SWRT_IMarshal>
 
     public init(_ owner: IUnknown) throws {

--- a/Support/Sources/WindowsRuntime/ComposableClass.swift
+++ b/Support/Sources/WindowsRuntime/ComposableClass.swift
@@ -85,7 +85,7 @@ open class ComposableClass: IInspectableProtocol {
 
             // Check for additional implemented interfaces.
             if let interfaceBinding = Self.queriableInterfaces.first(where: { $0.interfaceID == id }) {
-                return COMDelegatingExport(virtualTable: interfaceBinding.virtualTablePointer, implementer: self).toCOM()
+                return COMDelegatingTearOff(virtualTable: interfaceBinding.virtualTablePointer, implementer: self).toCOM()
             }
         }
 

--- a/Support/Sources/WindowsRuntime/ReferenceArrayImpl.swift
+++ b/Support/Sources/WindowsRuntime/ReferenceArrayImpl.swift
@@ -2,7 +2,7 @@ import WindowsRuntime_ABI
 
 /// Implements IReferenceArray<T> for any boxable T not provided by the UWP PropertyValue class (value types and delegates).
 internal class ReferenceArrayImpl<TBinding: IReferenceableBinding>
-        : WinRTExport<WindowsFoundation_IReferenceArrayBinding<TBinding>>,
+        : WinRTExportBase<WindowsFoundation_IReferenceArrayBinding<TBinding>>,
         WindowsFoundation_IReferenceArrayProtocol {
     public typealias T = TBinding.SwiftValue
 

--- a/Support/Sources/WindowsRuntime/ReferenceImpl.swift
+++ b/Support/Sources/WindowsRuntime/ReferenceImpl.swift
@@ -2,7 +2,7 @@ import WindowsRuntime_ABI
 
 /// Implements IReference<T> for any boxable T not provided by the UWP PropertyValue class (value types and delegates).
 internal class ReferenceImpl<TBinding: IReferenceableBinding>
-        : WinRTExport<WindowsFoundation_IReferenceBinding<TBinding>>,
+        : WinRTExportBase<WindowsFoundation_IReferenceBinding<TBinding>>,
         WindowsFoundation_IReferenceProtocol {
     public typealias T = TBinding.SwiftValue
 

--- a/Support/Sources/WindowsRuntime/WinRTError+LanguageException.swift
+++ b/Support/Sources/WindowsRuntime/WinRTError+LanguageException.swift
@@ -1,6 +1,6 @@
 extension WinRTError {
     /// Wraps a Swift Error object so it can be associated with an `IRestrictedErrorInfo`.
-    internal final class LanguageException: COMExport<IUnknownBinding> {
+    internal final class LanguageException: COMExportBase<IUnknownBinding> {
         public let error: Error
 
         public init(error: Error) {

--- a/Support/Sources/WindowsRuntime/WinRTTearOffBase.swift
+++ b/Support/Sources/WindowsRuntime/WinRTTearOffBase.swift
@@ -1,0 +1,13 @@
+import COM
+
+/// Base class for COM tear-off objects for interfaces derived from IInspectable.
+open class WinRTTearOffBase<Binding: InterfaceBinding>: COMTearOffBase<Binding>, IInspectableProtocol {
+    public init(owner: IInspectable) {
+        super.init(owner: owner)
+    }
+
+    // Delegate to the identity object, though we should be using that object's IInspectable implementation in the first place.
+    public func getIids() throws -> [COMInterfaceID] { try (owner as! IInspectable).getIids() }
+    public func getRuntimeClassName() throws -> String { try (owner as! IInspectable).getRuntimeClassName() }
+    public func getTrustLevel() throws -> TrustLevel { try (owner as! IInspectable).getTrustLevel() }
+}

--- a/Support/Tests/Tests/COMExportTests.swift
+++ b/Support/Tests/Tests/COMExportTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import WindowsRuntime
 
 internal final class COMExportTests: XCTestCase {
-    final class TestObject: COMExport<IUnknownBinding>, ICOMTestProtocol, ICOMTest2Protocol {
+    final class TestObject: COMExportBase<IUnknownBinding>, ICOMTestProtocol, ICOMTest2Protocol {
         override class var queriableInterfaces: [any COMTwoWayBinding.Type] { [
             ICOMTestBinding.self,
             ICOMTest2Binding.self
@@ -38,11 +38,11 @@ internal final class COMExportTests: XCTestCase {
     }
 
     func testIAgileObject() throws {
-        final class AgileObject: COMExport<IUnknownBinding> {
+        final class AgileObject: COMExportBase<IUnknownBinding> {
             override class var implementIAgileObject: Bool { true }
         }
 
-        final class NonAgileObject: COMExport<IUnknownBinding> {
+        final class NonAgileObject: COMExportBase<IUnknownBinding> {
             override class var implementIAgileObject: Bool { false }
         }
 
@@ -51,11 +51,11 @@ internal final class COMExportTests: XCTestCase {
     }
 
     func testFreeThreadedMarshalability() throws {
-        final class Marshalable: COMExport<IUnknownBinding> {
+        final class Marshalable: COMExportBase<IUnknownBinding> {
             override class var implementFreeThreadedMarshaling: Bool { true }
         }
 
-        final class NonMarshalable: COMExport<IUnknownBinding> {
+        final class NonMarshalable: COMExportBase<IUnknownBinding> {
             override class var implementFreeThreadedMarshaling: Bool { false }
         }
 
@@ -65,7 +65,7 @@ internal final class COMExportTests: XCTestCase {
     }
 
     func testSecondaryInterface() throws {
-        final class CallCounter: COMExport<IUnknownBinding>, ICOMTestProtocol {
+        final class CallCounter: COMExportBase<IUnknownBinding>, ICOMTestProtocol {
             override class var queriableInterfaces: [any COMTwoWayBinding.Type] { [
                 ICOMTestBinding.self
             ] }
@@ -84,7 +84,7 @@ internal final class COMExportTests: XCTestCase {
     }
 
     func testEmbeddedSecondaryInterface() throws {
-        final class CallCounter: COMExport<IUnknownBinding>, ICOMTestProtocol {
+        final class CallCounter: COMExportBase<IUnknownBinding>, ICOMTestProtocol {
             override class var queriableInterfaces: [any COMTwoWayBinding.Type] { [
                 ICOMTestBinding.self
             ] }

--- a/Support/Tests/Tests/WinRTExportTests.swift
+++ b/Support/Tests/Tests/WinRTExportTests.swift
@@ -3,7 +3,7 @@ import WindowsRuntime
 
 internal final class WinRTExportTests: XCTestCase {
     func testIInspectableIdentityRule() throws {
-        final class TestObject: WinRTExport<IInspectableBinding>, ICOMTestProtocol, IWinRTTestProtocol {
+        final class TestObject: WinRTExportBase<IInspectableBinding>, ICOMTestProtocol, IWinRTTestProtocol {
             override class var queriableInterfaces: [any COMTwoWayBinding.Type] { [
                 ICOMTestBinding.self,
                 IWinRTTestBinding.self
@@ -23,7 +23,7 @@ internal final class WinRTExportTests: XCTestCase {
     }
 
     func testGetIids() throws {
-        final class TestObject: WinRTExport<IInspectableBinding>, ICOMTestProtocol, IWinRTTestProtocol {
+        final class TestObject: WinRTExportBase<IInspectableBinding>, ICOMTestProtocol, IWinRTTestProtocol {
             override class var queriableInterfaces: [any COMTwoWayBinding.Type] { [
                 ICOMTestBinding.self,
                 IWinRTTestBinding.self
@@ -41,7 +41,7 @@ internal final class WinRTExportTests: XCTestCase {
     }
 
     func testIStringable() throws {
-        final class Stringable: WinRTExport<IInspectableBinding>, CustomStringConvertible {
+        final class Stringable: WinRTExportBase<IInspectableBinding>, CustomStringConvertible {
             var description: String { "hello" }
         }
 
@@ -49,11 +49,11 @@ internal final class WinRTExportTests: XCTestCase {
     }
 
     func testIWeakReferenceSource() throws {
-        final class WeakReferenceSource: WinRTExport<IInspectableBinding> {
+        final class WeakReferenceSource: WinRTExportBase<IInspectableBinding> {
             override class var implementIWeakReferenceSource: Bool { true }
         }
 
-        final class NonWeakReferenceSource: WinRTExport<IInspectableBinding> {
+        final class NonWeakReferenceSource: WinRTExportBase<IInspectableBinding> {
             override class var implementIWeakReferenceSource: Bool { false }
         }
 


### PR DESCRIPTION
Fixes #435