### PR TITLE
Introduce ComposableClass.OuterObject

### DIFF
--- a/Generator/Sources/ProjectionModel/SupportModules.swift
+++ b/Generator/Sources/ProjectionModel/SupportModules.swift
@@ -81,6 +81,8 @@ extension SupportModules.WinRT {
     public static var composableClassBinding: SwiftType { moduleType.member("ComposableClassBinding") }
 
     public static var composableClass: SwiftType { moduleType.member("ComposableClass") }
+    public static var composableClass_outerObject: SwiftType { composableClass.member("OuterObject") }
+    public static var composableClass_outerObject_shortName: String { "OuterObject" }
     public static var composableClass_supportsOverrides: String { "supportsOverrides" }
 
     public static func winRTImport(of type: SwiftType) -> SwiftType {

--- a/Generator/Sources/SwiftWinRT/Writing/ABIBinding.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ABIBinding.swift
@@ -275,19 +275,73 @@ fileprivate func writeClassBindingType(
             projection: projection,
             to: writer)
 
+        if !classDefinition.isSealed {
+            try writeComposableClassOuterObject(classDefinition, projection: projection, to: writer)
+        }
+    }
+}
+
+fileprivate func writeComposableClassOuterObject(
+        _ classDefinition: ClassDefinition,
+        projection: Projection,
+        to writer: SwiftTypeDefinitionWriter) throws {
+    let baseOuterObject: SwiftType
+    if let base = try classDefinition.base, try base.definition.base != nil {
+        // FIXME: Append .OuterObject
+        baseOuterObject = SwiftType.identifier(try projection.toBindingTypeName(base.definition))
+    } else {
+        // FIXME: Append .OuterObject
+        baseOuterObject = SupportModules.WinRT.composableClass
+    }
+
+    let outerObjectClassName = "OuterObject"
+
+    try writer.writeClass(
+            visibility: .open,
+            name: outerObjectClassName,
+            base: baseOuterObject) { writer in
         let overridableInterfaces = try classDefinition.baseInterfaces.compactMap {
             try $0.hasAttribute(OverridableAttribute.self) ? $0.interface : nil
         }
-        if !overridableInterfaces.isEmpty {
-            try writer.writeEnum(visibility: .internal, name: "VirtualTables") { writer in
-                for interface in overridableInterfaces {
-                    try writeVirtualTableProperty(
-                        visibility: .internal,
-                        name: Casing.pascalToCamel(interface.definition.nameWithoutGenericArity),
-                        abiType: interface.asBoundType, swiftType: classDefinition.bindType(),
-                        projection: projection, to: writer)
+        guard !overridableInterfaces.isEmpty else { return }
+
+        // public override func _queryInterface(_ id: COM.COMInterfaceID) throws -> COM.IUnknownReference {
+        try writer.writeFunc(
+                visibility: .public, override: true, name: "_queryInterface",
+                params: [ .init(label: "_", name: "id", type: SupportModules.COM.comInterfaceID) ], throws: true,
+                returnType: SupportModules.COM.iunknownReference) { writer in
+            for interface in overridableInterfaces {
+                // if id == uuidof(SWRT_IFoo.self) {
+                let abiSwiftType = try projection.toABIType(interface.asBoundType)
+                writer.writeBracedBlock("if id == uuidof(\(abiSwiftType).self)") { writer in
+                    let propertyName = SecondaryInterfaces.getPropertyName(interface)
+
+                    // _ifoo_outer.initEmbedder(self)
+                    // return .init(_ifoo_outer.toCOM())
+                    writer.writeStatement("\(propertyName).initEmbedder(self)")
+                    writer.writeReturnStatement(value: ".init(\(propertyName).toCOM())")
                 }
             }
+
+            writer.writeReturnStatement(value: "try super._queryInterface(id)")
+        }
+
+        for interface in overridableInterfaces {
+            // private var _ifoo: COM.COMEmbedding = .init(virtualTable: &OuterObject.istringable, embedder: nil)
+            let vtablePropertyName = Casing.pascalToCamel(interface.definition.nameWithoutGenericArity)
+            writer.writeStoredProperty(
+                visibility: .private, declarator: .var,
+                name: SecondaryInterfaces.getPropertyName(interface),
+                type: SupportModules.COM.comEmbedding,
+                initialValue: ".init(virtualTable: &\(outerObjectClassName).\(vtablePropertyName), embedder: nil)")
+        }
+
+        for interface in overridableInterfaces {
+            try writeVirtualTableProperty(
+                visibility: .internal,
+                name: Casing.pascalToCamel(interface.definition.nameWithoutGenericArity),
+                abiType: interface.asBoundType, swiftType: classDefinition.bindType(),
+                projection: projection, to: writer)
         }
     }
 }

--- a/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
@@ -134,14 +134,6 @@ fileprivate func writeClassMembers(
 
     // var _lazyFoo: COM.COMReference<SWRT_IFoo>.Optional = .none
     try writeSecondaryInterfaces(classDefinition, interfaces: interfaces, projection: projection, to: writer)
-
-    if !classDefinition.isSealed { // Composable
-        let overridableInterfaces = interfaces.secondary.compactMap { $0.overridable ? $0.interface : nil }
-        if !overridableInterfaces.isEmpty {
-            writer.writeMarkComment("Override support")
-            try writeOverrideSupport(classDefinition, interfaces: overridableInterfaces, projection: projection, to: writer)
-        }
-    }
 }
 
 fileprivate func writeInterfaceImplementations(
@@ -251,43 +243,6 @@ fileprivate func writeSecondaryInterfaces(
     }
 }
 
-fileprivate func writeOverrideSupport(
-        _ classDefinition: ClassDefinition, interfaces: [BoundInterface],
-        projection: Projection, to writer: SwiftTypeDefinitionWriter) throws {
-    let outerPropertySuffix = "outer"
-
-    for interface in interfaces {
-        // private var _ifoo_outer: COM.COMEmbedding = .init(
-        //     virtualTable: &SWRT_IStringable.VirtualTables.IStringable, embedder: nil)
-        let bindingTypeName = try projection.toBindingTypeName(classDefinition)
-        let vtablePropertyName = Casing.pascalToCamel(interface.definition.nameWithoutGenericArity)
-        writer.writeStoredProperty(
-            visibility: .private, declarator: .var,
-            name: SecondaryInterfaces.getPropertyName(interface, suffix: outerPropertySuffix),
-            type: SupportModules.COM.comEmbedding,
-            initialValue: ".init(virtualTable: &\(bindingTypeName).VirtualTables.\(vtablePropertyName), embedder: nil)")
-    }
-
-    // public override func _queryOverridesInterface(_ id: COM.COMInterfaceID) throws -> COM.IUnknownReference.Optional {
-    try writer.writeFunc(
-            visibility: .public, override: true, name: "_queryOverridesInterface",
-            params: [ .init(label: "_", name: "id", type: SupportModules.COM.comInterfaceID) ], throws: true,
-            returnType: SupportModules.COM.iunknownReference_Optional) { writer in
-        for interface in interfaces {
-            // if id == uuidof(SWRT_IFoo.self) {
-            let abiSwiftType = try projection.toABIType(interface.asBoundType)
-            writer.writeBracedBlock("if id == uuidof(\(abiSwiftType).self)") { writer in
-                let outerPropertyName = SecondaryInterfaces.getPropertyName(interface, suffix: outerPropertySuffix)
-
-                // _ifoo_outer.initEmbedder(self)
-                // return .init(_ifoo_outer.toCOM())
-                writer.writeStatement("\(outerPropertyName).initEmbedder(self)")
-                writer.writeReturnStatement(value: ".init(\(outerPropertyName).toCOM())")
-            }
-        }
-        writer.writeReturnStatement(value: ".none")
-    }
-}
 
 fileprivate func writeMarkComment(forInterface interface: BoundInterface, to writer: SwiftTypeDefinitionWriter) throws {
     let interfaceName = try WinRTTypeName.from(type: interface.asBoundType).description
@@ -304,6 +259,7 @@ fileprivate func writeComposableInitializers(
     let propertyName = SecondaryInterfaces.getPropertyName(factoryInterface.bind())
 
     let baseClassDefinition = try getRuntimeClassBase(classDefinition)
+    let outerObjectType = SwiftType.identifier(try projection.toBindingTypeName(classDefinition))
 
     for method in factoryInterface.methods {
         // Swift requires "override" on initializers iff the same initializer is defined in the direct base class
@@ -323,7 +279,7 @@ fileprivate func writeComposableInitializers(
                 params: params.dropLast(2).map { $0.toSwiftParam() }, // Drop inner and outer pointer params
                 throws: true) { writer in
             let output = writer.output
-            try output.writeLineBlock(header: "try super.init {", footer: "}") {
+            try output.writeLineBlock(header: "try super.init(_outer: \(outerObjectType).self) {", footer: "}") {
                 let outerObjectParamName = params[params.count - 2].name
                 let innerObjectParamName = params[params.count - 1].name
                 output.writeFullLine("(\(outerObjectParamName), \(innerObjectParamName): inout IInspectablePointer?) in")
@@ -449,12 +405,15 @@ fileprivate func writeDelegatingWrappingInitializer(
 
 fileprivate func writeDelegatingComposableInitializer(
         defaultInterface: BoundInterface, projection: Projection, to writer: SwiftTypeDefinitionWriter) throws {
-    // public init<ABIStruct>(_factory: ComposableFactory<ABIStruct>) throws {
+    // public init<ABIStruct>(_outer: OuterObject.Type, _factory: ComposableFactory<ABIStruct>) throws {
     writer.writeInit(visibility: .public,
             override: true,
             genericParams: [ "ABIStruct" ],
-            params: [ SwiftParam(name: "_factory", type: .named("ComposableFactory", genericArgs: [.named("ABIStruct") ])) ],
+            params: [
+                SwiftParam(name: "_outer", type: .named("OuterObject").member("Type")),
+                SwiftParam(name: "_factory", type: .named("ComposableFactory", genericArgs: [ .named("ABIStruct") ]))
+            ],
             throws: true) { writer in
-        writer.writeStatement("try super.init(_factory: _factory)")
+        writer.writeStatement("try super.init(_outer: _outer, _factory: _factory)")
     }
 }

--- a/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/ClassDefinition.swift
@@ -259,7 +259,7 @@ fileprivate func writeComposableInitializers(
     let propertyName = SecondaryInterfaces.getPropertyName(factoryInterface.bind())
 
     let baseClassDefinition = try getRuntimeClassBase(classDefinition)
-    let outerObjectType = SwiftType.identifier(try projection.toBindingTypeName(classDefinition))
+    let outerObjectType: SwiftType = .named(try projection.toBindingTypeName(classDefinition)).member("OuterObject")
 
     for method in factoryInterface.methods {
         // Swift requires "override" on initializers iff the same initializer is defined in the direct base class

--- a/Generator/Sources/SwiftWinRT/Writing/SecondaryInterfaces.swift
+++ b/Generator/Sources/SwiftWinRT/Writing/SecondaryInterfaces.swift
@@ -60,18 +60,12 @@ internal enum SecondaryInterfaces {
         })
     }
 
-    internal static func getPropertyName(_ interface: BoundInterface, suffix: String? = nil) -> String {
-        getPropertyName(interfaceName: interface.definition.nameWithoutGenericArity, suffix: suffix)
+    internal static func getPropertyName(_ interface: BoundInterface) -> String {
+        getPropertyName(interfaceName: interface.definition.nameWithoutGenericArity)
     }
 
-    internal static func getPropertyName(interfaceName: String, suffix: String? = nil) -> String {
-        var name = "_" + Casing.pascalToCamel(interfaceName)
-        if let suffix { name += "_" + suffix }
-        return name
-    }
-
-    internal static func getOverridableOuterName(_ interface: BoundInterface) -> String {
-        "_outer" + interface.definition.nameWithoutGenericArity
+    internal static func getPropertyName(interfaceName: String) -> String {
+        "_" + Casing.pascalToCamel(interfaceName)
     }
 
     fileprivate static func getStoredPropertyName(_ interfaceName: String) -> String {

--- a/Support/Sources/COM/COMDelegatingTearOff.swift
+++ b/Support/Sources/COM/COMDelegatingTearOff.swift
@@ -4,14 +4,14 @@ import COM_ABI
 public final class COMDelegatingTearOff: COMEmbedderEx {
     private var comEmbedding: COMEmbedding
 
-    public init(virtualTable: UnsafeRawPointer, implementer: IUnknown) {
+    public init(virtualTable: UnsafeRawPointer, owner: IUnknown) {
         comEmbedding = .init(virtualTable: virtualTable, embedder: nil)
-        super.init(implementer: implementer)
+        super.init(implementer: owner)
         comEmbedding.initEmbedder(self)
     }
 
-    public convenience init<Binding: COMTwoWayBinding>(binding: Binding.Type, implementer: Binding.SwiftObject) {
-        self.init(virtualTable: Binding.virtualTablePointer, implementer: implementer as! IUnknown)
+    public convenience init<Binding: COMTwoWayBinding>(binding: Binding.Type, owner: Binding.SwiftObject) {
+        self.init(virtualTable: Binding.virtualTablePointer, owner: owner as! IUnknown)
     }
 
     public func toCOM() -> IUnknownReference { comEmbedding.toCOM() }

--- a/Support/Sources/COM/COMEmbedding+statics.swift
+++ b/Support/Sources/COM/COMEmbedding+statics.swift
@@ -57,7 +57,9 @@ extension COMEmbedding {
         }
 
         let implementer = implementerObject as? Implementer
-        assert(implementer != nil, "Bad COM object embedding. \(type(of: implementerObject)) does not provide the expected implementation of \(Implementer.self).")
+        // The use of "String(describing:)" is a workaround for a bogus compiler error on Swift 5.10
+        assert(implementer != nil, "Bad COM object embedding."
+            + " \(String(describing: type(of: implementerObject))) does not provide the expected implementation of \(Implementer.self).")
         return implementer!
     }
 

--- a/Support/Sources/COM/COMEmbedding+statics.swift
+++ b/Support/Sources/COM/COMEmbedding+statics.swift
@@ -57,9 +57,7 @@ extension COMEmbedding {
         }
 
         let implementer = implementerObject as? Implementer
-        // The use of "String(describing:)" is a workaround for a bogus compiler error on Swift 5.10
-        assert(implementer != nil, "Bad COM object embedding."
-            + " \(String(describing: type(of: implementerObject))) does not provide the expected implementation of \(Implementer.self).")
+        assert(implementer != nil, "Bad COM object embedding. Did not provide the expected implementation of \(Implementer.self).")
         return implementer!
     }
 

--- a/Support/Sources/COM/COMEmbedding+statics.swift
+++ b/Support/Sources/COM/COMEmbedding+statics.swift
@@ -48,7 +48,7 @@ extension COMEmbedding {
         let opaquePointer = UnsafeMutableRawPointer(bitPattern: embedderAndFlags & ~SWRT_COMEmbeddingFlags_Mask)
         assert(opaquePointer != nil, "Bad COM object embedding. The embedder pointer is nil.")
 
-        let implementerObject: AnyObject?
+        let implementerObject: AnyObject
         if (embedderAndFlags & SWRT_COMEmbeddingFlags_Extended) != 0 {
             // COMEmbedding asserted that we can reinterpret cast to COMEmbedderEx.
             implementerObject = Unmanaged<COMEmbedderEx>.fromOpaque(opaquePointer!).takeUnretainedValue().implementer
@@ -57,7 +57,7 @@ extension COMEmbedding {
         }
 
         let implementer = implementerObject as? Implementer
-        assert(implementer != nil, "Bad COM object embedding. Did not provide the expected implementation of \(Implementer.self).")
+        assert(implementer != nil, "Bad COM object embedding. \(type(of: implementerObject)) does not provide the expected implementation of \(Implementer.self).")
         return implementer!
     }
 

--- a/Support/Sources/COM/COMExportBase.swift
+++ b/Support/Sources/COM/COMExportBase.swift
@@ -26,7 +26,7 @@ open class COMExportBase<PrimaryInterfaceBinding: COMTwoWayBinding>: IUnknownPro
                 return try FreeThreadedMarshal(self).toCOM().cast()
             default:
                 if let interfaceBinding = Self.queriableInterfaces.first(where: { $0.interfaceID == id }) {
-                    return COMDelegatingTearOff(virtualTable: interfaceBinding.virtualTablePointer, implementer: self).toCOM()
+                    return COMDelegatingTearOff(virtualTable: interfaceBinding.virtualTablePointer, owner: self).toCOM()
                 }
                 throw COMError.noInterface
         }

--- a/Support/Sources/WindowsRuntime/ComposableClass.swift
+++ b/Support/Sources/WindowsRuntime/ComposableClass.swift
@@ -96,6 +96,8 @@ open class ComposableClass: IInspectableProtocol {
         // which transitively keeps us alive.
         fileprivate var comEmbedding: COMEmbedding
 
+        public var owner: ComposableClass { comEmbedding.embedder as! ComposableClass }
+
         public required init(owner: ComposableClass) {
             self.comEmbedding = .init(virtualTable: IInspectableBinding.virtualTablePointer, embedder: nil)
             self.comEmbedding.initEmbedder(owner)
@@ -106,8 +108,6 @@ open class ComposableClass: IInspectableProtocol {
             if id == IUnknownBinding.interfaceID || id == IInspectableBinding.interfaceID {
                 return comEmbedding.toCOM()
             }
-
-            let owner = comEmbedding.embedder as! ComposableClass
 
             // Check for additional implemented interfaces.
             if let interfaceBinding = type(of: owner).queriableInterfaces.first(where: { $0.interfaceID == id }) {


### PR DESCRIPTION
Lifts unsealed class overrides support to a separate object such that the size overhead is only paid when deriving from those classes in Swift.

Fixes #64 .