### PR TITLE
Fix CMake link dependencies for flat modules

### DIFF
--- a/Generator/Sources/SwiftWinRT/writeProjectionFiles.swift
+++ b/Generator/Sources/SwiftWinRT/writeProjectionFiles.swift
@@ -206,7 +206,7 @@ fileprivate func writeNamespaceModules(
     compactNamespaces.sort()
 
     try writeFlatNamespaceModule(
-        moduleName: module.name + "_Flat",
+        module: module,
         namespaceModuleNames: compactNamespaces.map { module.getNamespaceModuleName(namespace: $0) },
         cmakeOptions: cmakeOptions,
         directoryPath: "\(directoryPath)\\Flat")


### PR DESCRIPTION
Follow regular namespace modules' example of linking against the projection module.

Fixes #456 (speculatively)